### PR TITLE
Implements bufferable put requests

### DIFF
--- a/datatype/imageblk/write.go
+++ b/datatype/imageblk/write.go
@@ -163,7 +163,6 @@ func (d *Data) PutVoxels(v dvid.VersionID, vox *Voxels, roiname dvid.InstanceNam
 
 	// extract buffer interface if it exists
 	var putbuffer storage.RequestBuffer
-	putbuffer = nil
 	store, err := storage.MutableStore()
 	if err != nil {
 		return fmt.Errorf("Data type imageblk had error initializing store: %v\n", err)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -437,9 +437,6 @@ type KeyValueRequester interface {
 type BufferableOps interface {
 	KeyValueSetter
 
-	// PutCallback writes a value with given key in a possibly versioned context and calls the call back when finished.
-	PutCallback(Context, TKey, []byte, func()) error
-
 	// Put key-value pairs.  Note that it could be more efficient to use the Batcher
 	// interface so you don't have to create and keep a slice of KeyValue.  Some
 	// databases like leveldb will copy on batch put anyway.
@@ -460,6 +457,9 @@ type BufferableOps interface {
 // of these operations.
 type RequestBuffer interface {
 	BufferableOps
+
+	// PutCallback writes a value with given key in a possibly versioned context and calls the call back when finished.
+	PutCallback(Context, TKey, []byte, func()) error
 
 	// Flush processes all the queued jobs
 	Flush() error

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -437,6 +437,9 @@ type KeyValueRequester interface {
 type BufferableOps interface {
 	KeyValueSetter
 
+	// PutCallback writes a value with given key in a possibly versioned context and calls the call back when finished.
+	PutCallback(Context, TKey, []byte, func()) error
+
 	// Put key-value pairs.  Note that it could be more efficient to use the Batcher
 	// interface so you don't have to create and keep a slice of KeyValue.  Some
 	// databases like leveldb will copy on batch put anyway.


### PR DESCRIPTION
This allows puts into gbucket to occur much faster.  I was able to load a 512x512x512 volume (grayscale or labeblk) in 10-20 seconds.  

I noticed that the server is running out of memory on small google VMs (<16 GB).  It is unclear whether this is because the new buffering code is inefficient or whether this is an old issue masked previously since DVID is usually run on much larger machines.

* This code change should not impact the previous implementation but a full regression should be run before accepting the request. *