### PR TITLE
makes gbucket buffer operation thread safe

### DIFF
--- a/storage/gbucket/gbucket.go
+++ b/storage/gbucket/gbucket.go
@@ -854,7 +854,7 @@ func (db *GBucket) NewBuffer(ctx storage.Context) storage.RequestBuffer {
 		dvid.Criticalf("Received nil context in NewBatch()")
 		return nil
 	}
-	return &goBuffer{db: db, ctx: ctx, ops: make([]dbOp, 0)}
+	return &goBuffer{db: db, ctx: ctx}
 }
 
 // --- implement RequestBuffer interface ---


### PR DESCRIPTION
I noticed that in one of my PUT calls  I was calling the gbucket buffer in different threads.  I added a simple lock to prevent contention in a shared data structure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/janelia-flyem/dvid/136)
<!-- Reviewable:end -->
