### PR TITLE
Added labelsz data type

### DIFF
--- a/cmd/dvid/main.go
+++ b/cmd/dvid/main.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/janelia-flyem/dvid/datatype/keyvalue"
 	_ "github.com/janelia-flyem/dvid/datatype/labelblk"
 	_ "github.com/janelia-flyem/dvid/datatype/labelgraph"
+	_ "github.com/janelia-flyem/dvid/datatype/labelsz"
 	_ "github.com/janelia-flyem/dvid/datatype/labelvol"
 	_ "github.com/janelia-flyem/dvid/datatype/multichan16"
 	_ "github.com/janelia-flyem/dvid/datatype/roi"

--- a/datatype/annotation/element_test.go
+++ b/datatype/annotation/element_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/janelia-flyem/dvid/datastore"
-	"github.com/janelia-flyem/dvid/datatype/labelblk"
 	"github.com/janelia-flyem/dvid/dvid"
 	"github.com/janelia-flyem/dvid/server"
 )
@@ -673,7 +672,7 @@ func TestLabels(t *testing.T) {
 	// Populate the labels, which should automatically populate the labelvol
 	_ = createLabelTestVolume(t, uuid, "labels")
 
-	if err := labelblk.BlockOnUpdating(uuid, "labels"); err != nil {
+	if err := datastore.BlockOnUpdating(uuid, "labels"); err != nil {
 		t.Fatalf("Error blocking on sync of labels: %v\n", err)
 	}
 
@@ -712,7 +711,7 @@ func TestLabels(t *testing.T) {
 	// Make change to labelblk and make sure our label synapses have been adjusted (case A)
 	_ = modifyLabelTestVolume(t, uuid, "labels")
 
-	if err := BlockOnUpdating(uuid, "mysynapses"); err != nil {
+	if err := datastore.BlockOnUpdating(uuid, "mysynapses"); err != nil {
 		t.Fatalf("Error blocking on sync of labels->annotations: %v\n", err)
 	}
 
@@ -727,8 +726,12 @@ func TestLabels(t *testing.T) {
 	testMerge := mergeJSON(`[2, 3]`)
 	testMerge.send(t, uuid, "bodies")
 
-	if err := labelblk.BlockOnUpdating(uuid, "labels"); err != nil {
+	if err := datastore.BlockOnUpdating(uuid, "labels"); err != nil {
 		t.Fatalf("Error blocking on sync of labels: %v\n", err)
+	}
+
+	if err := datastore.BlockOnUpdating(uuid, "mysynapses"); err != nil {
+		t.Fatalf("Error blocking on sync of synapses: %v\n", err)
 	}
 
 	testResponseLabel(t, expectedLabel1, "%snode/%s/mysynapses/label/1?relationships=true", server.WebAPIPath, uuid)
@@ -757,7 +760,7 @@ func TestLabels(t *testing.T) {
 	}
 
 	// Verify that the annotations are correct.
-	if err := BlockOnUpdating(uuid, "mysynapses"); err != nil {
+	if err := datastore.BlockOnUpdating(uuid, "mysynapses"); err != nil {
 		t.Fatalf("Error blocking on sync of split->annotations: %v\n", err)
 	}
 	testResponseLabel(t, expectedLabel2c, "%snode/%s/mysynapses/label/2?relationships=true", server.WebAPIPath, uuid)
@@ -790,7 +793,7 @@ func TestLabels(t *testing.T) {
 	}
 
 	// Verify that the annotations are correct.
-	if err := BlockOnUpdating(uuid, "renamedData"); err != nil {
+	if err := datastore.BlockOnUpdating(uuid, "renamedData"); err != nil {
 		t.Fatalf("Error blocking on sync of split->annotations: %v\n", err)
 	}
 	testResponseLabel(t, expectedLabel2c, "%snode/%s/renamedData/label/8?relationships=true", server.WebAPIPath, uuid)

--- a/datatype/imagetile/push.go
+++ b/datatype/imagetile/push.go
@@ -22,7 +22,7 @@ func (d *Data) NewFilter(fs storage.FilterSpec) (storage.Filter, error) {
 	filter := &Filter{Data: d, fs: fs}
 
 	// if there's no filter, just use base Data send.
-	roidata, roiV, roiFound, err := roi.DataBySpec(fs)
+	roidata, roiV, roiFound, err := roi.DataByFilter(fs)
 	if err != nil {
 		return nil, fmt.Errorf("No filter found that was parsable (%s): %v\n", fs, err)
 	}

--- a/datatype/labelblk/sync.go
+++ b/datatype/labelblk/sync.go
@@ -10,27 +10,12 @@ import (
 	"fmt"
 	"hash/fnv"
 	"sync"
-	"time"
 
 	"github.com/janelia-flyem/dvid/datastore"
 	"github.com/janelia-flyem/dvid/datatype/common/labels"
 	"github.com/janelia-flyem/dvid/dvid"
 	"github.com/janelia-flyem/dvid/storage"
 )
-
-// BlockOnUpdating blocks until the given data is not updating from syncs.
-// This is primarily used during testing.
-func BlockOnUpdating(uuid dvid.UUID, name dvid.InstanceName) error {
-	d, err := GetByUUIDName(uuid, name)
-	if err != nil {
-		return err
-	}
-	time.Sleep(100 * time.Millisecond)
-	for d.Updating() {
-		time.Sleep(50 * time.Millisecond)
-	}
-	return nil
-}
 
 // GetSyncSubs implements the datastore.Syncer interface
 func (d *Data) GetSyncSubs(synced dvid.Data) datastore.SyncSubs {

--- a/datatype/labelsz/keys.go
+++ b/datatype/labelsz/keys.go
@@ -1,0 +1,175 @@
+/*
+	This file supports keyspaces for the labelsz data type.
+*/
+
+package labelsz
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	"github.com/janelia-flyem/dvid/storage"
+
+	"github.com/janelia-flyem/dvid/datatype/annotation"
+)
+
+const (
+	// keyUnknown should never be used and is a check for corrupt or incorrectly set keys
+	keyUnknown storage.TKeyClass = iota
+
+	// key is index type + size + label
+	keyTypeSizeLabel = 97
+
+	// key is index type + label, with value equal to size, necessary to delete old indices.
+	keyTypeLabel = 98
+)
+
+const (
+	UnknownIndex IndexType = iota
+	PostSyn                // Post-synaptic element
+	PreSyn                 // Pre-synaptic element
+	Gap                    // Gap junction
+	Note                   // A note or bookmark with some description
+	AllSyn                 // PostSyn, PreSyn, or Gap
+	Voxels                 // Number of voxels
+)
+
+// IndexType gives the type of index.
+type IndexType uint8
+
+func (i IndexType) String() string {
+	switch i {
+	case PostSyn:
+		return "PostSyn"
+	case PreSyn:
+		return "PreSyn"
+	case Gap:
+		return "Gap"
+	case Note:
+		return "Note"
+	case AllSyn:
+		return "AllSyn"
+	case Voxels:
+		return "Voxels"
+	default:
+		return "Unknown IndexType"
+	}
+}
+
+// StringToIndexType converts a string to an IndexType
+func StringToIndexType(s string) IndexType {
+	switch s {
+	case "PostSyn":
+		return PostSyn
+	case "PreSyn":
+		return PreSyn
+	case "Gap":
+		return Gap
+	case "Note":
+		return Note
+	case "AllSyn":
+		return AllSyn
+	case "Voxels":
+		return Voxels
+	default:
+		return UnknownIndex
+	}
+}
+
+// can be used as map index and holds serialized (IndexType, Label)
+type indexedLabel string
+
+func (il indexedLabel) String() string {
+	i := IndexType(il[0])
+	labelBytes := []byte(il[1:])
+	label := binary.BigEndian.Uint64(labelBytes)
+	return fmt.Sprintf("[label %d, index %s]", label, i.String())
+}
+
+func toIndexedLabel(e annotation.ElementPos) indexedLabel {
+	var i IndexType
+	switch e.Kind {
+	case annotation.PostSyn:
+		i = PostSyn
+	case annotation.PreSyn:
+		i = PreSyn
+	case annotation.Gap:
+		i = Gap
+	case annotation.Note:
+		i = Note
+	}
+	return newIndexedLabel(i, e.Label)
+}
+
+func newIndexedLabel(i IndexType, label uint64) indexedLabel {
+	buf := make([]byte, 9)
+	buf[0] = byte(i)
+	binary.BigEndian.PutUint64(buf[1:], label)
+	return indexedLabel(buf)
+}
+
+func decodeIndexedLabel(il indexedLabel) (i IndexType, label uint64, err error) {
+	if len(il) != 9 {
+		err = fmt.Errorf("indexed label %v is supposed to be 9 bytes but is %d bytes", il, len(il))
+		return
+	}
+	i = IndexType(il[0])
+	labelBytes := []byte(il[1:])
+	label = binary.BigEndian.Uint64(labelBytes)
+	return
+}
+
+// NewTypeSizeLabelTKey returns a type-specific key for the (index type, size, label) tuple.
+func NewTypeSizeLabelTKey(i IndexType, sz uint32, label uint64) storage.TKey {
+	// Since we want biggest -> smallest sort and initially only have forward range queries,
+	// modify size to make smallest <-> largest.
+	rsz := math.MaxUint32 - sz
+
+	buf := make([]byte, 8+1+4)
+	buf[0] = byte(i)
+	binary.BigEndian.PutUint32(buf[1:5], rsz)
+	binary.BigEndian.PutUint64(buf[5:], label)
+	return storage.NewTKey(keyTypeSizeLabel, buf)
+}
+
+// DecodeTypeSizeLabelTKey decodes a type-specific key into a (index type, size, label) tuple.
+func DecodeTypeSizeLabelTKey(tk storage.TKey) (i IndexType, sz uint32, label uint64, err error) {
+	var ibytes []byte
+	ibytes, err = tk.ClassBytes(keyTypeSizeLabel)
+	if err != nil {
+		return
+	}
+	if len(ibytes) != 13 {
+		err = fmt.Errorf("labelsz element size type-specific key is wrong size: expected 13, got %d bytes", len(ibytes))
+		return
+	}
+	i = IndexType(ibytes[0])
+	sz = math.MaxUint32 - binary.BigEndian.Uint32(ibytes[1:5])
+	label = binary.BigEndian.Uint64(ibytes[5:])
+	return
+}
+
+// NewTypeLabelTKey returns a type-specific key for the (index type, label) tuple.
+func NewTypeLabelTKey(i IndexType, label uint64) storage.TKey {
+	buf := make([]byte, 1+8)
+	buf[0] = byte(i)
+	binary.BigEndian.PutUint64(buf[1:], label)
+	return storage.NewTKey(keyTypeLabel, buf)
+}
+
+// DecodeTypeLabelTKey decodes a type-specific key into a (index type, label) tuple.
+func DecodeTypeLabelTKey(tk storage.TKey) (i IndexType, label uint64, err error) {
+	var ibytes []byte
+	ibytes, err = tk.ClassBytes(keyTypeLabel)
+	if err != nil {
+		return
+	}
+	if len(ibytes) != 9 {
+		err = fmt.Errorf("labelsz label size type-specific key is wrong size: expected 9, got %d bytes", len(ibytes))
+		return
+	}
+	i = IndexType(ibytes[0])
+	label = binary.BigEndian.Uint64(ibytes[1:])
+	return
+}

--- a/datatype/labelsz/labelsz.go
+++ b/datatype/labelsz/labelsz.go
@@ -169,16 +169,15 @@ func (s LabelSizes) Swap(i, j int) {
 func NewData(uuid dvid.UUID, id dvid.InstanceID, name dvid.InstanceName, c dvid.Config) (*Data, error) {
 	// See if we have a valid DataService ROI
 	var roistr string
-	str, found, err := c.GetString("ROI")
+	roistr, found, err := c.GetString("ROI")
 	if err != nil {
 		return nil, err
 	}
 	if found {
-		parts := strings.Split(str, ",")
+		parts := strings.Split(roistr, ",")
 		if len(parts) != 2 {
-			return nil, fmt.Errorf("bad ROI value (%q) expected %q", str, "<roiname>,<uuid>")
+			return nil, fmt.Errorf("bad ROI value (%q) expected %q", roistr, "<roiname>,<uuid>")
 		}
-		roistr = "roi:" + str
 	}
 
 	// Initialize the Data for this data type
@@ -296,6 +295,7 @@ func (d *Data) GetTopElementType(ctx *datastore.VersionedCtx, n int, i IndexType
 	rank := 0
 	err = store.ProcessRange(ctx, begTKey, endTKey, nil, func(chunk *storage.Chunk) error {
 		idxType, sz, label, err := DecodeTypeSizeLabelTKey(chunk.K)
+		dvid.Infof("Got index type %s, sz %d, label %d\n", idxType, sz, label)
 		if err != nil {
 			return err
 		}
@@ -312,7 +312,7 @@ func (d *Data) GetTopElementType(ctx *datastore.VersionedCtx, n int, i IndexType
 	if err != shortCircuitErr && err != nil {
 		return nil, err
 	}
-	return lsz, nil
+	return lsz[:rank], nil
 }
 
 // GetByUUIDName returns a pointer to annotation data given a version (UUID) and data name.

--- a/datatype/labelsz/labelsz.go
+++ b/datatype/labelsz/labelsz.go
@@ -1,0 +1,483 @@
+/*
+	Package labelsz supports ranking labels by # annotations of each type.
+*/
+package labelsz
+
+import (
+	"bytes"
+	"encoding/gob"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/janelia-flyem/dvid/datastore"
+	"github.com/janelia-flyem/dvid/datatype/annotation"
+	"github.com/janelia-flyem/dvid/datatype/roi"
+	"github.com/janelia-flyem/dvid/dvid"
+	"github.com/janelia-flyem/dvid/server"
+	"github.com/janelia-flyem/dvid/storage"
+)
+
+const (
+	Version  = "0.1"
+	RepoURL  = "github.com/janelia-flyem/dvid/datatype/labelsz"
+	TypeName = "labelsz"
+)
+
+const HelpMessage = `
+API for labelsz data type (github.com/janelia-flyem/dvid/datatype/labelsz)
+=======================================================================================
+
+Command-line:
+
+$ dvid repo <UUID> new labelsz <data name> <settings...>
+
+	Adds newly named data of the 'type name' to repo with specified UUID.
+
+	Example:
+
+	$ dvid repo 3f8c new labelsz labelrankings
+
+    Arguments:
+
+    UUID           Hexidecimal string with enough characters to uniquely identify a version node.
+    data name      Name of data to create, e.g., "labelrankings"
+    settings       Configuration settings in "key=value" format separated by spaces.
+
+    Configuration Settings (case-insensitive keys)
+
+    ROI            Value must be in "<roiname>,<uuid>" format where <roiname> is the name of the
+				   static ROI that defines the extent of tracking and <uuid> is the immutable
+				   version used for this labelsz.
+	
+    ------------------
+
+HTTP API (Level 2 REST):
+
+GET  <api URL>/node/<UUID>/<data name>/help
+
+	Returns data-specific help message.
+
+
+GET  <api URL>/node/<UUID>/<data name>/info
+POST <api URL>/node/<UUID>/<data name>/info
+
+    Retrieves or puts DVID-specific data properties for this labelsz data instance.
+
+    Example: 
+
+    GET <api URL>/node/3f8c/labelrankings/info
+
+    Returns JSON with configuration settings.
+
+    Arguments:
+
+    UUID          Hexidecimal string with enough characters to uniquely identify a version node.
+    data name     Name of labelsz data.
+
+
+POST <api URL>/node/<UUID>/<data name>/sync
+
+    Establishes data instances for which the label sizes are computed.  Expects JSON to be POSTed
+    with the following format:
+
+    { "sync": "synapses" }
+
+    The "sync" property should be followed by a comma-delimited list of data instances that MUST
+    already exist.  After this sync request, the labelsz data are computed for the first time
+	and then kept in sync thereafter.  It is not allowed to change syncs.  You can, however,
+	create a new labelsz data instance and sync it as required.
+
+    The labelsz data type only accepts syncs to annotation data instances.
+
+
+Note: For the following URL endpoints that return and accept POSTed JSON values, see the JSON format
+at end of this documentation.
+
+GET <api URL>/node/<UUID>/<data name>/top/<N>/<index type>
+
+	Returns a list of the top N labels with respect to number of the specified index type.
+	The index type may be any annotation element type ("PostSyn", "PreSyn", "Gap", "Note"),
+	the catch-all for synapses "AllSyn", or the number of voxels "Voxels".
+
+	For synapse indexing, the labelsz data instance must be synced with an annotations instance.
+	(future) For # voxel indexing, the labelsz data instance must be synced with a labelvol instance.
+
+	Example:
+
+	GET <api URL>/node/3f8c/labelrankings/top/3/PreSyn 
+
+	Returns:
+
+	[ { "Label": 188,  "PreSyn": 81 }, { "Label": 23, "PreSyn": 65 }, { "Label": 8137, "PreSyn": 58 } ]
+
+`
+
+var (
+	dtype *Type
+)
+
+func init() {
+	dtype = new(Type)
+	dtype.Type = datastore.Type{
+		Name:    TypeName,
+		URL:     RepoURL,
+		Version: Version,
+		Requirements: &storage.Requirements{
+			Batcher: true,
+		},
+	}
+
+	// See doc for package on why channels are segregated instead of interleaved.
+	// Data types must be registered with the datastore to be used.
+	datastore.Register(dtype)
+
+	// Need to register types that will be used to fulfill interfaces.
+	gob.Register(&Type{})
+	gob.Register(&Data{})
+}
+
+// LabelSize is the count for a given label for some metric like # of PreSyn annotations.
+type LabelSize struct {
+	Label uint64
+	Size  uint32
+}
+
+// LabelSizes is a sortable slice of LabelSize
+type LabelSizes []LabelSize
+
+// --- Sort interface
+
+func (s LabelSizes) Len() int {
+	return len(s)
+}
+
+func (s LabelSizes) Less(i, j int) bool {
+	return s[i].Size < s[j].Size
+}
+
+func (s LabelSizes) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// NewData returns a pointer to labelsz data.
+func NewData(uuid dvid.UUID, id dvid.InstanceID, name dvid.InstanceName, c dvid.Config) (*Data, error) {
+	// See if we have a valid DataService ROI
+	var roistr string
+	str, found, err := c.GetString("ROI")
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		parts := strings.Split(str, ",")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("bad ROI value (%q) expected %q", str, "<roiname>,<uuid>")
+		}
+		roistr = "roi:" + str
+	}
+
+	// Initialize the Data for this data type
+	basedata, err := datastore.NewDataService(dtype, uuid, id, name, c)
+	if err != nil {
+		return nil, err
+	}
+	data := &Data{
+		Data: basedata,
+		Properties: Properties{
+			StaticROI: roistr,
+		},
+	}
+	return data, nil
+}
+
+// --- Labelsz Datatype -----
+
+type Type struct {
+	datastore.Type
+}
+
+// --- TypeService interface ---
+
+func (dtype *Type) NewDataService(uuid dvid.UUID, id dvid.InstanceID, name dvid.InstanceName, c dvid.Config) (datastore.DataService, error) {
+	return NewData(uuid, id, name, c)
+}
+
+func (dtype *Type) Help() string {
+	return HelpMessage
+}
+
+// Properties are additional properties for data beyond those in standard datastore.Data.
+type Properties struct {
+	// StaticROI is an optional static ROI specification of the form "<roiname>,<uuid>"
+	// Note that it *cannot* mutate after the labelsz instance is created.
+	StaticROI string
+}
+
+// Data instance of labelvol, label sparse volumes.
+type Data struct {
+	*datastore.Data
+	Properties
+
+	// Keep track of sync operations that could be updating the data.
+	datastore.Updater
+
+	sync.RWMutex
+
+	// cache of immutable ROI on which this labelsz is filtered if any.
+	iMutex     sync.Mutex
+	iROI       *roi.Immutable
+	roiChecked bool
+}
+
+func (d *Data) Equals(d2 *Data) bool {
+	if !d.Data.Equals(d2.Data) {
+		return false
+	}
+	return reflect.DeepEqual(d.Properties, d2.Properties)
+}
+
+func (d *Data) GetSyncedAnnotation() *annotation.Data {
+	for dataUUID := range d.SyncedData() {
+		source, err := annotation.GetByDataUUID(dataUUID)
+		if err == nil {
+			return source
+		}
+	}
+	return nil
+}
+
+func (d *Data) inROI(e annotation.ElementPos) bool {
+	if d.StaticROI == "" {
+		return true // no ROI so ROI == everything
+	}
+
+	// Make sure we have immutable ROI if specified.
+	d.iMutex.Lock()
+	if !d.roiChecked {
+		d.roiChecked = true
+		iROI, err := roi.ImmutableBySpec(d.StaticROI)
+		if err != nil {
+			dvid.Errorf("could not load immutable ROI by spec %q: %v\n", d.StaticROI, err)
+			d.iMutex.Unlock()
+			return false
+		}
+		d.iROI = iROI
+	}
+	d.iMutex.Unlock()
+
+	if d.iROI == nil {
+		return false // ROI cannot be retrieved so use nothing; makes obvious failure since no ranks.
+	}
+	return d.iROI.VoxelWithin(e.Pos)
+}
+
+// GetTopElementType returns a sorted list of the top N labels that have the given ElementType.
+func (d *Data) GetTopElementType(ctx *datastore.VersionedCtx, n int, i IndexType) (LabelSizes, error) {
+	store, err := d.GetOrderedKeyValueDB()
+	if err != nil {
+		return nil, err
+	}
+
+	// Setup key range for iterating through keys of this ElementType.
+	begTKey := NewTypeSizeLabelTKey(i, math.MaxUint32-1, 0)
+	endTKey := NewTypeSizeLabelTKey(i, 0, math.MaxUint64)
+
+	d.RLock()
+	defer d.RUnlock()
+
+	// Iterate through the first N kv then abort.
+	shortCircuitErr := fmt.Errorf("Found data, aborting.")
+	lsz := make(LabelSizes, n)
+	rank := 0
+	err = store.ProcessRange(ctx, begTKey, endTKey, nil, func(chunk *storage.Chunk) error {
+		idxType, sz, label, err := DecodeTypeSizeLabelTKey(chunk.K)
+		if err != nil {
+			return err
+		}
+		if idxType != i {
+			return fmt.Errorf("bad iteration of keys: expected index type %s, got %s", i, idxType)
+		}
+		lsz[rank] = LabelSize{Label: label, Size: sz}
+		rank++
+		if rank >= n {
+			return shortCircuitErr
+		}
+		return nil
+	})
+	if err != shortCircuitErr && err != nil {
+		return nil, err
+	}
+	return lsz, nil
+}
+
+// GetByUUIDName returns a pointer to annotation data given a version (UUID) and data name.
+func GetByUUIDName(uuid dvid.UUID, name dvid.InstanceName) (*Data, error) {
+	source, err := datastore.GetDataByUUIDName(uuid, name)
+	if err != nil {
+		return nil, err
+	}
+	data, ok := source.(*Data)
+	if !ok {
+		return nil, fmt.Errorf("Instance '%s' is not a labelsz datatype!", name)
+	}
+	return data, nil
+}
+
+// --- datastore.DataService interface ---------
+
+func (d *Data) Help() string {
+	return HelpMessage
+}
+
+func (d *Data) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Base     *datastore.Data
+		Extended Properties
+	}{
+		d.Data,
+		d.Properties,
+	})
+}
+
+func (d *Data) GobDecode(b []byte) error {
+	buf := bytes.NewBuffer(b)
+	dec := gob.NewDecoder(buf)
+	if err := dec.Decode(&(d.Data)); err != nil {
+		return err
+	}
+	if err := dec.Decode(&(d.Properties)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *Data) GobEncode() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	if err := enc.Encode(d.Data); err != nil {
+		return nil, err
+	}
+	if err := enc.Encode(d.Properties); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// DoRPC acts as a switchboard for RPC commands.
+func (d *Data) DoRPC(request datastore.Request, reply *datastore.Response) error {
+	switch request.TypeCommand() {
+	default:
+		return fmt.Errorf("Unknown command.  Data type '%s' [%s] does not support '%s' command.",
+			d.DataName(), d.TypeName(), request.TypeCommand())
+	}
+	return nil
+}
+
+// ServeHTTP handles all incoming HTTP requests for this data.
+func (d *Data) ServeHTTP(uuid dvid.UUID, ctx *datastore.VersionedCtx, w http.ResponseWriter, r *http.Request) {
+	timedLog := dvid.NewTimeLog()
+
+	// Get the action (GET, POST)
+	action := strings.ToLower(r.Method)
+
+	// Break URL request into arguments
+	url := r.URL.Path[len(server.WebAPIPath):]
+	parts := strings.Split(url, "/")
+	if len(parts[len(parts)-1]) == 0 {
+		parts = parts[:len(parts)-1]
+	}
+
+	// Handle POST on data -> setting of configuration
+	if len(parts) == 3 && action == "put" {
+		config, err := server.DecodeJSON(r)
+		if err != nil {
+			server.BadRequest(w, r, err)
+			return
+		}
+		if err := d.ModifyConfig(config); err != nil {
+			server.BadRequest(w, r, err)
+			return
+		}
+		if err := datastore.SaveDataByUUID(uuid, d); err != nil {
+			server.BadRequest(w, r, err)
+			return
+		}
+		fmt.Fprintf(w, "Changed '%s' based on received configuration:\n%s\n", d.DataName(), config)
+		return
+	}
+
+	if len(parts) < 4 {
+		server.BadRequest(w, r, "Incomplete API request")
+		return
+	}
+
+	// Process help and info.
+	switch parts[3] {
+	case "help":
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprintln(w, dtype.Help())
+
+	case "info":
+		jsonBytes, err := d.MarshalJSON()
+		if err != nil {
+			server.BadRequest(w, r, err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, string(jsonBytes))
+
+	case "sync":
+		if action != "post" {
+			server.BadRequest(w, r, "Only POST allowed to sync endpoint")
+			return
+		}
+		if err := datastore.SetSyncByJSON(d, uuid, r.Body); err != nil {
+			server.BadRequest(w, r, err)
+			return
+		}
+
+	case "top":
+		if action != "get" {
+			server.BadRequest(w, r, "Only GET action is available on 'top' endpoint.")
+			return
+		}
+		if len(parts) < 6 {
+			server.BadRequest(w, r, "Must include N and element type after 'top' endpoint.")
+			return
+		}
+		n, err := strconv.ParseUint(parts[4], 10, 32)
+		if err != nil {
+			server.BadRequest(w, r, err)
+			return
+		}
+		i := StringToIndexType(parts[5])
+		if i == UnknownIndex {
+			server.BadRequest(w, r, fmt.Errorf("unknown index type specified (%q)", parts[5]))
+			return
+		}
+		labelSizes, err := d.GetTopElementType(ctx, int(n), i)
+		if err != nil {
+			server.BadRequest(w, r, err)
+			return
+		}
+		w.Header().Set("Content-type", "application/json")
+		jsonBytes, err := json.Marshal(labelSizes)
+		if err != nil {
+			server.BadRequest(w, r, err)
+			return
+		}
+		if _, err := w.Write(jsonBytes); err != nil {
+			server.BadRequest(w, r, err)
+			return
+		}
+		timedLog.Infof("HTTP %s: get top %d labels for index type %s: %s", r.Method, n, i, r.URL)
+
+	default:
+		server.BadAPIRequest(w, r, d)
+	}
+}

--- a/datatype/labelsz/labelsz_test.go
+++ b/datatype/labelsz/labelsz_test.go
@@ -1,0 +1,28 @@
+package labelsz
+
+import (
+	"log"
+	"sync"
+
+	"github.com/janelia-flyem/dvid/datastore"
+	"github.com/janelia-flyem/dvid/dvid"
+)
+
+var (
+	syntype datastore.TypeService
+	testMu  sync.Mutex
+)
+
+// Sets package-level testRepo and TestVersionID
+func initTestRepo() (dvid.UUID, dvid.VersionID) {
+	testMu.Lock()
+	defer testMu.Unlock()
+	if syntype == nil {
+		var err error
+		syntype, err = datastore.TypeServiceByName(TypeName)
+		if err != nil {
+			log.Fatalf("Can't get synapse type: %s\n", err)
+		}
+	}
+	return datastore.NewTestRepo()
+}

--- a/datatype/labelsz/labelsz_test.go
+++ b/datatype/labelsz/labelsz_test.go
@@ -1,16 +1,26 @@
 package labelsz
 
 import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
 	"log"
+	"strings"
 	"sync"
+	"testing"
 
 	"github.com/janelia-flyem/dvid/datastore"
+	"github.com/janelia-flyem/dvid/datatype/annotation"
 	"github.com/janelia-flyem/dvid/dvid"
+	"github.com/janelia-flyem/dvid/server"
 )
 
 var (
-	syntype datastore.TypeService
-	testMu  sync.Mutex
+	syntype     datastore.TypeService
+	testMu      sync.Mutex
+	synapseData annotation.Elements
 )
 
 // Sets package-level testRepo and TestVersionID
@@ -25,4 +35,367 @@ func initTestRepo() (dvid.UUID, dvid.VersionID) {
 		}
 	}
 	return datastore.NewTestRepo()
+}
+
+// A slice of bytes representing 3d label volume
+type testVolume struct {
+	data []byte
+	size dvid.Point3d
+}
+
+func newTestVolume(nx, ny, nz int32) *testVolume {
+	return &testVolume{
+		data: make([]byte, nx*ny*nz*8),
+		size: dvid.Point3d{nx, ny, nz},
+	}
+}
+
+// Sets voxels in body to given label.
+func (v *testVolume) add(label uint64, ox, oy, oz int32, sx, sy, sz int32) {
+	nx := v.size.Value(0)
+	ny := v.size.Value(1)
+	nxy := nx * ny
+	for z := oz; z < oz+sz; z++ {
+		for y := oy; y < oy+sy; y++ {
+			p := (z*nxy + y*nx + ox) * 8
+			for x := ox; x < ox+sx; x++ {
+				binary.LittleEndian.PutUint64(v.data[p:p+8], label)
+				p += 8
+			}
+		}
+	}
+}
+
+// Put label data into given data instance.
+func (v *testVolume) put(t *testing.T, uuid dvid.UUID, name string) {
+	apiStr := fmt.Sprintf("%snode/%s/%s/raw/0_1_2/%d_%d_%d/0_0_0?mutate=true", server.WebAPIPath,
+		uuid, name, v.size[0], v.size[1], v.size[2])
+	server.TestHTTP(t, "POST", apiStr, bytes.NewBuffer(v.data))
+}
+
+func createLabelTestVolume(t *testing.T, uuid dvid.UUID, name string) *testVolume {
+	volume := newTestVolume(128, 128, 128)
+	volume.add(100, 0, 0, 0, 64, 128, 128)
+	volume.add(200, 64, 0, 0, 64, 128, 64)
+	volume.add(300, 64, 0, 64, 64, 128, 64)
+
+	// Send data over HTTP to populate a data instance
+	volume.put(t, uuid, name)
+	return volume
+}
+
+var testSpans = []dvid.Span{
+	dvid.Span{1, 1, 1, 2}, dvid.Span{1, 2, 1, 2},
+	dvid.Span{2, 1, 1, 2}, dvid.Span{2, 2, 1, 2},
+}
+
+func getROIReader() io.Reader {
+	jsonBytes, err := json.Marshal(testSpans)
+	if err != nil {
+		log.Fatalf("Can't encode spans into JSON: %v\n", err)
+	}
+	return bytes.NewReader(jsonBytes)
+}
+
+type mergeJSON string
+
+func (mjson mergeJSON) send(t *testing.T, uuid dvid.UUID, name string) {
+	apiStr := fmt.Sprintf("%snode/%s/%s/merge", server.WebAPIPath, uuid, name)
+	server.TestHTTP(t, "POST", apiStr, bytes.NewBuffer([]byte(mjson)))
+}
+
+func getBytesRLE(t *testing.T, rles dvid.RLEs) *bytes.Buffer {
+	n := len(rles)
+	buf := new(bytes.Buffer)
+	buf.WriteByte(dvid.EncodingBinary)
+	binary.Write(buf, binary.LittleEndian, uint8(3))  // # of dimensions
+	binary.Write(buf, binary.LittleEndian, byte(0))   // dimension of run (X = 0)
+	buf.WriteByte(byte(0))                            // reserved for later
+	binary.Write(buf, binary.LittleEndian, uint32(0)) // Placeholder for # voxels
+	binary.Write(buf, binary.LittleEndian, uint32(n)) // Placeholder for # spans
+	rleBytes, err := rles.MarshalBinary()
+	if err != nil {
+		t.Errorf("Unable to serialize RLEs: %v\n", err)
+	}
+	buf.Write(rleBytes)
+	return buf
+}
+
+func TestLabels(t *testing.T) {
+	datastore.OpenTest()
+	defer datastore.CloseTest()
+
+	// Create testbed volume and data instances
+	uuid, _ := initTestRepo()
+	var config dvid.Config
+	server.CreateTestInstance(t, uuid, "labelblk", "labels", config)
+	server.CreateTestInstance(t, uuid, "labelvol", "bodies", config)
+
+	// Establish syncs
+	server.CreateTestSync(t, uuid, "labels", "bodies")
+	server.CreateTestSync(t, uuid, "bodies", "labels")
+
+	// Populate the labels, which should automatically populate the labelvol
+	_ = createLabelTestVolume(t, uuid, "labels")
+
+	if err := datastore.BlockOnUpdating(uuid, "labels"); err != nil {
+		t.Fatalf("Error blocking on sync of labels: %v\n", err)
+	}
+
+	// Add annotations syncing with "labels" instance.
+	server.CreateTestInstance(t, uuid, "annotation", "mysynapses", config)
+	server.CreateTestSync(t, uuid, "mysynapses", "labels,bodies")
+
+	// Create a ROI that will be used for our labelsz.
+	server.CreateTestInstance(t, uuid, "roi", "myroi", config)
+	roiRequest := fmt.Sprintf("%snode/%s/myroi/roi", server.WebAPIPath, uuid)
+	server.TestHTTP(t, "POST", roiRequest, getROIReader())
+
+	// Create labelsz instances synced to the above annotations.
+	server.CreateTestInstance(t, uuid, "labelsz", "noroi", config)
+	server.CreateTestSync(t, uuid, "noroi", "mysynapses")
+	config.Set("ROI", fmt.Sprintf("myroi,%s", uuid))
+	server.CreateTestInstance(t, uuid, "labelsz", "withroi", config)
+	server.CreateTestSync(t, uuid, "withroi", "mysynapses")
+
+	// PUT first batch of synapses.
+	var synapses annotation.Elements
+	var x, y, z int32
+	// This should put 31x31x31 (29,791) PostSyn in volume with fewer in label 200 than 300.
+	// There will be 15 along each dimension from 0 -> 63, then 16 from 64 -> 127.
+	// Label 100 will have 15 x 31 x 31 = 14415
+	// Label 200 will have 16 x 31 x 15 = 7440
+	// Label 300 will have 16 x 31 x 16 = 7936
+	for z = 4; z < 128; z += 4 {
+		for y = 4; y < 128; y += 4 {
+			for x = 4; x < 128; x += 4 {
+				e := annotation.Element{
+					annotation.ElementNR{
+						Pos:  dvid.Point3d{x, y, z},
+						Kind: annotation.PostSyn,
+					},
+					[]annotation.Relationship{},
+				}
+				synapses = append(synapses, e)
+			}
+		}
+	}
+	// This should put 32x32x32 (32,768) PreSyn in volume split 1/2, 1/4, 1/4
+	for z = 2; z < 128; z += 4 {
+		for y = 2; y < 128; y += 4 {
+			for x = 2; x < 128; x += 4 {
+				e := annotation.Element{
+					annotation.ElementNR{
+						Pos:  dvid.Point3d{x, y, z},
+						Kind: annotation.PreSyn,
+					},
+					[]annotation.Relationship{},
+				}
+				synapses = append(synapses, e)
+			}
+		}
+	}
+	testJSON, err := json.Marshal(synapses)
+	if err != nil {
+		t.Fatal(err)
+	}
+	url := fmt.Sprintf("%snode/%s/mysynapses/elements", server.WebAPIPath, uuid)
+	server.TestHTTP(t, "POST", url, strings.NewReader(string(testJSON)))
+
+	// Check if we have correct sequencing for no ROI labelsz.
+	if err := datastore.BlockOnUpdating(uuid, "noroi"); err != nil {
+		t.Fatalf("Error blocking on sync of noroi labelsz: %v\n", err)
+	}
+
+	url = fmt.Sprintf("%snode/%s/noroi/top/3/PreSyn", server.WebAPIPath, uuid)
+	data := server.TestHTTP(t, "GET", url, nil)
+	if string(data) != `[{"Label":100,"Size":16384},{"Label":200,"Size":8192},{"Label":300,"Size":8192}]` {
+		t.Errorf("Got back incorrect could PreSyn noroi ranking:\n%v\n", string(data))
+	}
+
+	url = fmt.Sprintf("%snode/%s/noroi/top/3/PostSyn", server.WebAPIPath, uuid)
+	data = server.TestHTTP(t, "GET", url, nil)
+	if string(data) != `[{"Label":100,"Size":14415},{"Label":300,"Size":7936},{"Label":200,"Size":7440}]` {
+		t.Errorf("Got back incorrect could PostSyn noroi ranking:\n%v\n", string(data))
+	}
+
+	// Check if we have correct sequencing for ROI labelsz.
+	// ROI constitutes the inner eight 32^3 blocks.
+	// There are 16 PostSyn in each ROI dimension.
+	// There are also 16 PreSyn in each ROI dimension.
+	if err := datastore.BlockOnUpdating(uuid, "withroi"); err != nil {
+		t.Fatalf("Error blocking on sync of withroi labelsz: %v\n", err)
+	}
+
+	url = fmt.Sprintf("%snode/%s/withroi/top/3/PreSyn", server.WebAPIPath, uuid)
+	data = server.TestHTTP(t, "GET", url, nil)
+	if string(data) != `[{"Label":100,"Size":2048},{"Label":200,"Size":1024},{"Label":300,"Size":1024}]` {
+		t.Errorf("Got back incorrect could PreSyn noroi ranking:\n%v\n", string(data))
+	}
+
+	url = fmt.Sprintf("%snode/%s/withroi/top/3/PostSyn", server.WebAPIPath, uuid)
+	data = server.TestHTTP(t, "GET", url, nil)
+	if string(data) != `[{"Label":100,"Size":2048},{"Label":200,"Size":1024},{"Label":300,"Size":1024}]` {
+		t.Errorf("Got back incorrect could PostSyn noroi ranking:\n%v\n", string(data))
+	}
+
+	// Check fewer and larger N requests.
+	url = fmt.Sprintf("%snode/%s/noroi/top/2/PreSyn", server.WebAPIPath, uuid)
+	data = server.TestHTTP(t, "GET", url, nil)
+	if string(data) != `[{"Label":100,"Size":16384},{"Label":200,"Size":8192}]` {
+		t.Errorf("Got back incorrect N=2 ranking:\n%v\n", string(data))
+	}
+
+	url = fmt.Sprintf("%snode/%s/noroi/top/4/PreSyn", server.WebAPIPath, uuid)
+	data = server.TestHTTP(t, "GET", url, nil)
+	if string(data) != `[{"Label":100,"Size":16384},{"Label":200,"Size":8192},{"Label":300,"Size":8192}]` {
+		t.Errorf("Got back incorrect N=4 ranking:\n%v\n", string(data))
+	}
+
+	// Test annotation move of a PostSyn from label 100->300 and also label 200->300
+	url = fmt.Sprintf("%snode/%s/mysynapses/move/32_32_32/75_21_69", server.WebAPIPath, uuid)
+	server.TestHTTP(t, "POST", url, nil)
+
+	url = fmt.Sprintf("%snode/%s/mysynapses/move/68_20_20/77_21_69", server.WebAPIPath, uuid)
+	server.TestHTTP(t, "POST", url, nil)
+
+	if err := datastore.BlockOnUpdating(uuid, "noroi"); err != nil {
+		t.Fatalf("Error blocking on sync of noroi labelsz: %v\n", err)
+	}
+
+	url = fmt.Sprintf("%snode/%s/noroi/top/3/PostSyn", server.WebAPIPath, uuid)
+	data = server.TestHTTP(t, "GET", url, nil)
+	if string(data) != `[{"Label":100,"Size":14414},{"Label":300,"Size":7938},{"Label":200,"Size":7439}]` {
+		t.Errorf("Got back incorrect could PostSyn noroi ranking after move from label 100->300:\n%v\n", string(data))
+	}
+
+	// Test annotation deletion of moved PostSyn from label 300
+	url = fmt.Sprintf("%snode/%s/mysynapses/element/75_21_69", server.WebAPIPath, uuid)
+	server.TestHTTP(t, "DELETE", url, nil)
+
+	url = fmt.Sprintf("%snode/%s/mysynapses/element/77_21_69", server.WebAPIPath, uuid)
+	server.TestHTTP(t, "DELETE", url, nil)
+
+	if err := datastore.BlockOnUpdating(uuid, "noroi"); err != nil {
+		t.Fatalf("Error blocking on sync of noroi labelsz: %v\n", err)
+	}
+
+	url = fmt.Sprintf("%snode/%s/noroi/top/3/PostSyn", server.WebAPIPath, uuid)
+	data = server.TestHTTP(t, "GET", url, nil)
+	if string(data) != `[{"Label":100,"Size":14414},{"Label":300,"Size":7936},{"Label":200,"Size":7439}]` {
+		t.Errorf("Got back incorrect could PostSyn noroi ranking after deletions from label 300:\n%v\n", string(data))
+	}
+
+	// Check sync on merge.
+	if err := datastore.BlockOnUpdating(uuid, "bodies"); err != nil {
+		t.Fatalf("Error blocking on sync of bodies: %v\n", err)
+	}
+	testMerge := mergeJSON(`[200, 300]`)
+	testMerge.send(t, uuid, "bodies")
+
+	if err := datastore.BlockOnUpdating(uuid, "labels"); err != nil {
+		t.Fatalf("Error blocking on sync of labels: %v\n", err)
+	}
+	if err := datastore.BlockOnUpdating(uuid, "mysynapses"); err != nil {
+		t.Fatalf("Error blocking on sync of synapses: %v\n", err)
+	}
+	if err := datastore.BlockOnUpdating(uuid, "noroi"); err != nil {
+		t.Fatalf("Error blocking on sync of labelsz: %v\n", err)
+	}
+
+	url = fmt.Sprintf("%snode/%s/noroi/top/3/PreSyn", server.WebAPIPath, uuid)
+	data = server.TestHTTP(t, "GET", url, nil)
+	if string(data) != `[{"Label":100,"Size":16384},{"Label":200,"Size":16384}]` {
+		t.Errorf("Got back incorrect post-merge PreSyn noroi ranking:\n%v\n", string(data))
+	}
+
+	url = fmt.Sprintf("%snode/%s/noroi/top/3/PostSyn", server.WebAPIPath, uuid)
+	data = server.TestHTTP(t, "GET", url, nil)
+	if string(data) != `[{"Label":200,"Size":15375},{"Label":100,"Size":14414}]` {
+		t.Errorf("Got back incorrect post-merge PostSyn noroi ranking:\n%v\n", string(data))
+	}
+
+	// Create the sparsevol encoding for split area with label 100 -> 150.
+	// Split has offset (0, 0, 0) with size (19, 19, 19).
+	// PreSyn in split = 5 x 5 x 5 = 125
+	// PostSyn in split = 4 x 4 x 4 = 64
+	var rles dvid.RLEs
+	for z := int32(0); z < 19; z++ {
+		for y := int32(0); y < 19; y++ {
+			start := dvid.Point3d{0, y, z}
+			rles = append(rles, dvid.NewRLE(start, 19))
+		}
+	}
+	buf := getBytesRLE(t, rles)
+
+	// Submit the split sparsevol
+	url = fmt.Sprintf("%snode/%s/%s/split/%d?splitlabel=150", server.WebAPIPath, uuid, "bodies", 100)
+	data = server.TestHTTP(t, "POST", url, buf)
+	jsonVal := make(map[string]uint64)
+	if err := json.Unmarshal(data, &jsonVal); err != nil {
+		t.Errorf("Unable to get new label from split.  Instead got: %v\n", jsonVal)
+	}
+
+	// Check sync on split.
+	if err := datastore.BlockOnUpdating(uuid, "labels"); err != nil {
+		t.Fatalf("Error blocking on sync of labels: %v\n", err)
+	}
+	if err := datastore.BlockOnUpdating(uuid, "mysynapses"); err != nil {
+		t.Fatalf("Error blocking on sync of synapses: %v\n", err)
+	}
+	if err := datastore.BlockOnUpdating(uuid, "noroi"); err != nil {
+		t.Fatalf("Error blocking on sync of labelsz: %v\n", err)
+	}
+
+	url = fmt.Sprintf("%snode/%s/noroi/top/3/PreSyn", server.WebAPIPath, uuid)
+	data = server.TestHTTP(t, "GET", url, nil)
+	if string(data) != `[{"Label":200,"Size":16384},{"Label":100,"Size":16259},{"Label":150,"Size":125}]` {
+		t.Errorf("Got back incorrect post-split PreSyn noroi ranking:\n%v\n", string(data))
+	}
+
+	url = fmt.Sprintf("%snode/%s/noroi/top/3/PostSyn", server.WebAPIPath, uuid)
+	data = server.TestHTTP(t, "GET", url, nil)
+	if string(data) != `[{"Label":200,"Size":15375},{"Label":100,"Size":14350},{"Label":150,"Size":64}]` {
+		t.Errorf("Got back incorrect post-split PostSyn noroi ranking:\n%v\n", string(data))
+	}
+
+	// Create the encoding for coarse split area in block coordinates from label 200.
+	// Split has offset (64, 96, 96) with size (64, 32, 32).
+	// PreSyn in split = 16 x 8 x 8 = 1024
+	// PostSyn in split = 16 x 8 x 8 = 1024
+	rles = dvid.RLEs{
+		dvid.NewRLE(dvid.Point3d{2, 3, 3}, 2),
+	}
+	buf = getBytesRLE(t, rles)
+
+	// Submit the coarse split of 200 -> 250
+	url = fmt.Sprintf("%snode/%s/%s/split-coarse/200?splitlabel=250", server.WebAPIPath, uuid, "bodies")
+	data = server.TestHTTP(t, "POST", url, buf)
+	jsonVal = make(map[string]uint64)
+	if err := json.Unmarshal(data, &jsonVal); err != nil {
+		t.Errorf("Unable to get new label from split.  Instead got: %v\n", jsonVal)
+	}
+
+	// Check sync on split.
+	if err := datastore.BlockOnUpdating(uuid, "labels"); err != nil {
+		t.Fatalf("Error blocking on sync of labels: %v\n", err)
+	}
+	if err := datastore.BlockOnUpdating(uuid, "mysynapses"); err != nil {
+		t.Fatalf("Error blocking on sync of synapses: %v\n", err)
+	}
+	if err := datastore.BlockOnUpdating(uuid, "noroi"); err != nil {
+		t.Fatalf("Error blocking on sync of labelsz: %v\n", err)
+	}
+
+	url = fmt.Sprintf("%snode/%s/noroi/top/5/PreSyn", server.WebAPIPath, uuid)
+	data = server.TestHTTP(t, "GET", url, nil)
+	if string(data) != `[{"Label":100,"Size":16259},{"Label":200,"Size":15360},{"Label":250,"Size":1024},{"Label":150,"Size":125}]` {
+		t.Errorf("Got back incorrect post-coarsesplit PreSyn noroi ranking:\n%v\n", string(data))
+	}
+
+	url = fmt.Sprintf("%snode/%s/noroi/top/5/PostSyn", server.WebAPIPath, uuid)
+	data = server.TestHTTP(t, "GET", url, nil)
+	if string(data) != `[{"Label":200,"Size":14351},{"Label":100,"Size":14350},{"Label":250,"Size":1024},{"Label":150,"Size":64}]` {
+		t.Errorf("Got back incorrect post-coarsesplit PostSyn noroi ranking:\n%v\n", string(data))
+	}
 }

--- a/datatype/labelsz/sync.go
+++ b/datatype/labelsz/sync.go
@@ -1,0 +1,205 @@
+package labelsz
+
+import (
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"github.com/janelia-flyem/dvid/datastore"
+	"github.com/janelia-flyem/dvid/datatype/annotation"
+	"github.com/janelia-flyem/dvid/dvid"
+	"github.com/janelia-flyem/dvid/storage"
+)
+
+// Number of change messages we can buffer before blocking on sync channel.
+const syncBufferSize = 100
+
+// BlockOnUpdating blocks until the given data is not updating from syncs.
+// This is primarily used during testing.
+func BlockOnUpdating(uuid dvid.UUID, name dvid.InstanceName) error {
+	time.Sleep(100 * time.Millisecond)
+	d, err := GetByUUIDName(uuid, name)
+	if err != nil {
+		return err
+	}
+	for d.Updating() {
+		time.Sleep(50 * time.Millisecond)
+	}
+	return nil
+}
+
+// GetSyncSubs implements the datastore.Syncer interface.  Returns a list of subscriptions
+// to the sync data instance that will notify the receiver.
+func (d *Data) GetSyncSubs(synced dvid.Data) datastore.SyncSubs {
+	modifyCh := make(chan datastore.SyncMessage, syncBufferSize)
+	modifyDone := make(chan struct{})
+
+	// setCh := make(chan datastore.SyncMessage, syncBufferSize)
+	// setDone := make(chan struct{})
+
+	subs := datastore.SyncSubs{
+		datastore.SyncSub{
+			Event:  datastore.SyncEvent{synced.DataUUID(), annotation.ModifyElementsEvent},
+			Notify: d.DataUUID(),
+			Ch:     modifyCh,
+			Done:   modifyDone,
+		},
+		// datastore.SyncSub{
+		// 	Event:  datastore.SyncEvent{synced.DataUUID(), annotation.SetElementsEvent},
+		// 	Notify: d.DataUUID(),
+		// 	Ch:     setCh,
+		// 	Done:   setDone,
+		// },
+	}
+
+	// Launch handlers of sync events.
+	go d.syncElementModify(modifyCh, modifyDone)
+	// go d.syncElementSet(setCh, setDone)
+
+	return subs
+}
+
+// If annotation elements are added or deleted, adjust the label counts.
+func (d *Data) syncElementModify(in <-chan datastore.SyncMessage, done <-chan struct{}) {
+	batcher, err := d.GetKeyValueBatcher()
+	if err != nil {
+		dvid.Errorf("Exiting sync goroutine for labelsz %q after annotation modifications: %v\n", d.DataName(), err)
+		return
+	}
+	for msg := range in {
+		select {
+		case <-done:
+			return
+		default:
+			d.StartUpdate()
+			ctx := datastore.NewVersionedCtx(d, msg.Version)
+			switch delta := msg.Delta.(type) {
+			case annotation.DeltaModifyElements:
+				d.modifyElements(ctx, delta, batcher)
+			default:
+				dvid.Criticalf("Cannot sync annotations from modify element.  Got unexpected delta: %v\n", msg)
+			}
+			d.StopUpdate()
+		}
+	}
+}
+
+// returned map will only include labels that had previously been seen (has key)
+func (d *Data) getCounts(ctx *datastore.VersionedCtx, labels map[indexedLabel]int32) (counts map[indexedLabel]uint32, err error) {
+	var store storage.OrderedKeyValueDB
+	store, err = d.GetOrderedKeyValueDB()
+	if err != nil {
+		return
+	}
+
+	counts = make(map[indexedLabel]uint32, len(labels))
+	var i IndexType
+	var label uint64
+	var val []byte
+	for il := range labels {
+		i, label, err = decodeIndexedLabel(il)
+		if err != nil {
+			return
+		}
+
+		val, err = store.Get(ctx, NewTypeLabelTKey(i, label))
+		if err != nil {
+			return
+		}
+		if val == nil {
+			continue
+		}
+		if len(val) != 4 {
+			err = fmt.Errorf("bad size in value for index type %s, label %d: value has length %d", i, label, len(val))
+			return
+		}
+		counts[il] = binary.LittleEndian.Uint32(val)
+	}
+	return
+}
+
+func (d *Data) modifyElements(ctx *datastore.VersionedCtx, delta annotation.DeltaModifyElements, batcher storage.KeyValueBatcher) {
+	mods := make(map[indexedLabel]int32)
+	for _, elemPos := range delta.Add {
+		if d.inROI(elemPos) {
+			i := toIndexedLabel(elemPos)
+			mods[i]++
+			if elemPos.Kind.IsSynaptic() {
+				i = newIndexedLabel(AllSyn, elemPos.Label)
+				mods[i]++
+			}
+		}
+	}
+	for _, elemPos := range delta.Del {
+		if d.inROI(elemPos) {
+			i := toIndexedLabel(elemPos)
+			mods[i]--
+			if elemPos.Kind.IsSynaptic() {
+				i = newIndexedLabel(AllSyn, elemPos.Label)
+				mods[i]--
+			}
+		}
+	}
+
+	d.Lock()
+	defer d.Unlock()
+
+	// Get old counts for the modified labels.
+	counts, err := d.getCounts(ctx, mods)
+	if err != nil {
+		dvid.Errorf("couldn't get counts for modified labels: %v\n", err)
+		return
+	}
+
+	// Modify the keys based on the change in counts, then delete or store.
+	batch := batcher.NewBatch(ctx)
+	for il, change := range mods {
+		if change == 0 {
+			continue
+		}
+		i, label, err := decodeIndexedLabel(il)
+		if err != nil {
+			dvid.Criticalf("couldn't decode indexedLabel %s for modify elements sync of %s: %v\n", il, d.DataName(), err)
+			continue
+		}
+
+		// check if we had prior key that needs to be deleted.
+		count, found := counts[il]
+		if found {
+			batch.Delete(NewTypeSizeLabelTKey(i, count, label))
+		}
+
+		// add new count
+		if change < 0 && -change > int32(count) {
+			dvid.Criticalf("received element mod that would subtract %d with only count %d!  Setting floor at 0.\n", -change, count)
+			change = int32(-count)
+		}
+		newcount := uint32(int32(count) + change)
+		buf := make([]byte, 4)
+		binary.LittleEndian.PutUint32(buf, newcount)
+		batch.Put(NewTypeLabelTKey(i, label), buf)
+		batch.Put(NewTypeSizeLabelTKey(i, newcount, label), nil)
+	}
+
+	if err := batch.Commit(); err != nil {
+		dvid.Criticalf("bad commit in labelsz %q during sync of modify elements: %v\n", d.DataName(), err)
+		return
+	}
+}
+
+/*
+func (d *Data) syncSet(in <-chan datastore.SyncMessage, done <-chan struct{}) {
+	batcher, err := d.GetKeyValueBatcher()
+	if err != nil {
+		dvid.Errorf("Exiting sync goroutine for labelsz %q after annotation sets: %v\n", d.DataName(), err)
+		return
+	}
+	for msg := range in {
+		select {
+		case <-done:
+			return
+		default:
+		}
+	}
+}
+*/

--- a/datatype/labelvol/labelvol_test.go
+++ b/datatype/labelvol/labelvol_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/janelia-flyem/dvid/datastore"
-	"github.com/janelia-flyem/dvid/datatype/labelblk"
 	"github.com/janelia-flyem/dvid/dvid"
 	"github.com/janelia-flyem/dvid/server"
 
@@ -320,7 +319,7 @@ func TestSparseVolumes(t *testing.T) {
 	// Populate the labels, which should automatically populate the labelvol
 	_ = createLabelTestVolume(t, uuid, "labels")
 
-	if err := BlockOnUpdating(uuid, "bodies"); err != nil {
+	if err := datastore.BlockOnUpdating(uuid, "bodies"); err != nil {
 		t.Fatalf("Error blocking on sync of labels -> bodies: %v\n", err)
 	}
 
@@ -458,7 +457,7 @@ func TestMergeLabels(t *testing.T) {
 	expected := createLabelTestVolume(t, uuid, "labels")
 	expected.add(body3, 2)
 
-	if err := BlockOnUpdating(uuid, "bodies"); err != nil {
+	if err := datastore.BlockOnUpdating(uuid, "bodies"); err != nil {
 		t.Fatalf("Error blocking on sync of labels -> bodies: %v\n", err)
 	}
 
@@ -486,7 +485,7 @@ func TestMergeLabels(t *testing.T) {
 	server.TestBadHTTP(t, "GET", reqStr, nil)
 
 	// Make sure label changes are correct after completion
-	if err := labelblk.BlockOnUpdating(uuid, "labels"); err != nil {
+	if err := datastore.BlockOnUpdating(uuid, "labels"); err != nil {
 		t.Fatalf("Error blocking on sync of bodies -> labels: %v\n", err)
 	}
 
@@ -526,7 +525,7 @@ func TestSplitLabel(t *testing.T) {
 	expected.add(bodyleft, 4)
 	expected.add(bodysplit, 5)
 
-	if err := BlockOnUpdating(uuid, "bodies"); err != nil {
+	if err := datastore.BlockOnUpdating(uuid, "bodies"); err != nil {
 		t.Fatalf("Error blocking on sync of labels -> bodies: %v\n", err)
 	}
 
@@ -582,7 +581,7 @@ func TestSplitLabel(t *testing.T) {
 		t.Errorf("Expected split label to be 5, instead got %d\n", newlabel)
 	}
 
-	if err := labelblk.BlockOnUpdating(uuid, "labels"); err != nil {
+	if err := datastore.BlockOnUpdating(uuid, "labels"); err != nil {
 		t.Fatalf("Error blocking on sync of bodies -> labels: %v\n", err)
 	}
 
@@ -633,7 +632,7 @@ func TestSplitGivenLabel(t *testing.T) {
 	expected.add(bodyleft, 4)
 	expected.add(bodysplit, 23)
 
-	if err := BlockOnUpdating(uuid, "bodies"); err != nil {
+	if err := datastore.BlockOnUpdating(uuid, "bodies"); err != nil {
 		t.Fatalf("Error blocking on sync of labels -> bodies: %v\n", err)
 	}
 
@@ -718,7 +717,7 @@ func TestSplitCoarseLabel(t *testing.T) {
 		}
 	}
 
-	if err := BlockOnUpdating(uuid, "bodies"); err != nil {
+	if err := datastore.BlockOnUpdating(uuid, "bodies"); err != nil {
 		t.Fatalf("Error blocking on sync of labels -> bodies: %v\n", err)
 	}
 
@@ -761,7 +760,7 @@ func TestSplitCoarseLabel(t *testing.T) {
 		t.Errorf("Expected split label to be 5, instead got %d\n", newlabel)
 	}
 
-	if err := labelblk.BlockOnUpdating(uuid, "labels"); err != nil {
+	if err := datastore.BlockOnUpdating(uuid, "labels"); err != nil {
 		t.Fatalf("Error blocking on sync of bodies -> labels: %v\n", err)
 	}
 
@@ -818,7 +817,7 @@ func TestSplitCoarseGivenLabel(t *testing.T) {
 		}
 	}
 
-	if err := BlockOnUpdating(uuid, "bodies"); err != nil {
+	if err := datastore.BlockOnUpdating(uuid, "bodies"); err != nil {
 		t.Fatalf("Error blocking on sync of labels -> bodies: %v\n", err)
 	}
 
@@ -855,7 +854,7 @@ func TestSplitCoarseGivenLabel(t *testing.T) {
 		t.Errorf("Expected split label to be 8127, instead got %d\n", newlabel)
 	}
 
-	if err := labelblk.BlockOnUpdating(uuid, "labels"); err != nil {
+	if err := datastore.BlockOnUpdating(uuid, "labels"); err != nil {
 		t.Fatalf("Error blocking on sync of bodies -> labels: %v\n", err)
 	}
 
@@ -886,7 +885,7 @@ func TestMutableLabelblkPOST(t *testing.T) {
 	// Post labels 1-4
 	createLabelTestVolume(t, uuid, "labels")
 
-	if err := BlockOnUpdating(uuid, "bodies"); err != nil {
+	if err := datastore.BlockOnUpdating(uuid, "bodies"); err != nil {
 		t.Fatalf("Error blocking on sync of labels -> bodies: %v\n", err)
 	}
 
@@ -907,7 +906,7 @@ func TestMutableLabelblkPOST(t *testing.T) {
 	// Post labels 6-7
 	createLabelTest2Volume(t, uuid, "labels")
 
-	if err := BlockOnUpdating(uuid, "bodies"); err != nil {
+	if err := datastore.BlockOnUpdating(uuid, "bodies"); err != nil {
 		t.Fatalf("Error blocking on sync of labels -> bodies: %v\n", err)
 	}
 

--- a/datatype/labelvol/sync.go
+++ b/datatype/labelvol/sync.go
@@ -2,7 +2,6 @@ package labelvol
 
 import (
 	"encoding/binary"
-	"time"
 
 	"github.com/janelia-flyem/dvid/datastore"
 	"github.com/janelia-flyem/dvid/datatype/common/labels"
@@ -19,20 +18,6 @@ import (
 
 // Number of change messages we can buffer before blocking on sync channel.
 const syncBufferSize = 100
-
-// BlockOnUpdating blocks until the given data is not updating from syncs.
-// This is primarily used during testing.
-func BlockOnUpdating(uuid dvid.UUID, name dvid.InstanceName) error {
-	time.Sleep(100 * time.Millisecond)
-	d, err := GetByUUIDName(uuid, name)
-	if err != nil {
-		return err
-	}
-	for d.Updating() {
-		time.Sleep(50 * time.Millisecond)
-	}
-	return nil
-}
 
 // GetSyncSubs implements the datastore.Syncer interface
 func (d *Data) GetSyncSubs(synced dvid.Data) datastore.SyncSubs {


### PR DESCRIPTION
The labelsz data type can sync with annotations data type, providing ranking support.  In the future, it can be extended to include ranking of labels by voxel count.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/janelia-flyem/dvid/175)
<!-- Reviewable:end -->
