### PR TITLE
server_local: Allow TOML to contain relative paths

### DIFF
--- a/dvid/utils.go
+++ b/dvid/utils.go
@@ -147,6 +147,22 @@ func (fname Filename) HasExtensionPrefix(exts ...string) bool {
 	return false
 }
 
+// Converts the given (possibly) relative path into an absolute path,
+// relative to the given anchor directory, not the current working directory.
+// If the given relativePath is already an absolute path,
+// it is returned unchanged.
+func ConvertToAbsolute(relativePath string, anchorDir string) (string, error) {
+	if filepath.IsAbs(relativePath) {
+		return relativePath, nil
+	}
+	absDir, err := filepath.Abs(anchorDir)
+	if err != nil {
+		return relativePath, fmt.Errorf("Could not decode TOML config: %v\n", err)
+	}
+	absPath := filepath.Join(absDir, relativePath)
+	return absPath, nil
+}
+
 // DataFromPost returns data submitted in the given key of a POST request.
 func DataFromPost(r *http.Request, key string) ([]byte, error) {
 	f, _, err := r.FormFile(key)

--- a/server/server_local_test.go
+++ b/server/server_local_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"github.com/janelia-flyem/dvid/storage"
 )
 
 func loadConfigFile(t *testing.T, filename string) string {
@@ -33,5 +34,51 @@ func TestParseConfig(t *testing.T) {
 	}
 	if backendCfg.DefaultKVDB != "raid6" || backendCfg.DefaultLog != "mutationlog" || backendCfg.KVStore["grayscale:99ef22cd85f143f58a623bd22aad0ef7"] != "kvautobus" {
 		t.Errorf("Bad backend configuration retrieval: %v\n", backendCfg)
+	}
+}
+
+func TestTOMLConfigAbsolutePath(t *testing.T) {
+	// Initialize the filepath settings
+	var c tomlConfig
+	c.Server.WebClient = "dvid-distro/dvid-console"
+	c.Logging.Logfile = "./foobar.log"
+
+	c.Store = make(map[storage.Alias]storeConfig)
+
+	c.Store["foo"] = make(storeConfig)
+	c.Store["foo"]["engine"] = "basholeveldb"
+	c.Store["foo"]["path"] = "foo-storage-db"
+
+	c.Store["bar"] = make(storeConfig)
+	c.Store["bar"]["engine"] = "basholeveldb"
+	c.Store["bar"]["path"] = "/tmp/bar-storage-db" // Already absolute, should stay unchanged.
+
+	// Convert relative paths to absolute
+	c.ConvertPathsToAbsolute("/tmp/dvid-configs/myconfig.toml")
+
+	// Checks
+	if c.Server.WebClient != "/tmp/dvid-configs/dvid-distro/dvid-console" {
+		t.Errorf("WebClient not correctly converted to absolute path: %s", c.Server.WebClient)
+	}
+
+	if c.Logging.Logfile != "/tmp/dvid-configs/foobar.log" {
+		t.Errorf("Logfile not correctly converted to absolute path: %s", c.Logging.Logfile)
+	}
+
+	foo, _ := c.Store["foo"]
+	path, _ := foo["path"]
+	if path.(string) != "/tmp/dvid-configs/foo-storage-db" {
+		t.Errorf("[store.foo].path not correctly converted to absolute path: %s", path)
+	}
+
+	engine, _ := foo["engine"]
+	if engine.(string) != "basholeveldb" {
+		t.Errorf("[store.foo].engine should not have been touched: %s", path)
+	}
+
+	bar, _ := c.Store["bar"]
+	path, _ = bar["path"]
+	if path.(string) != "/tmp/bar-storage-db" {
+		t.Errorf("[store.bar].path was already absolute and should have been left unchanged: %s", path)
 	}
 }


### PR DESCRIPTION
Allow the dvid config TOML to contain relative paths for `webClient`, `logfile`, and store `path`.  Relative paths are interpreted as relative to the TOML file's directory (regardless of the user's `$PWD`).

Supports TOML files such as this:

```toml
[server]
httpAddress = ":8000"
rpcAddress = ":8001"
webClient = "../dvid-distro/dvid-console"

[logging]
logfile = "dvid.log"
max_log_size = 500
max_log_age = 30

[store]
    [store.raid6]
    engine = "basholeveldb"
    path = "./dbs/dvid-datastore"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/janelia-flyem/dvid/238)
<!-- Reviewable:end -->
