### PR TITLE
Small makefile tweaks

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -125,3 +125,9 @@ Build Maintenance Notes
   to the `source` section in `scripts/conda-recipe/meta.yaml`.
      
 - Of course, new DVID sources should be listed in the `Makefile` as needed.
+
+
+Memory profiling
+----------------
+
+DVID uses [an integrated memory profiling system](https://github.com/wblakecaldwell/profiler/tree/d0f7b0590a127b0c7ef1abf7c089ef2fa74b47cd).  To start memory profiling, visit `http://path-to-dvid-server/profiler/start`.  You can then visit `http://path-to-dvid-server/profiler/info.html` to view the real-time graph of memory usage.  Stop profiling by visiting `http://path-to-dvid-server/profiler/stop`.

--- a/Makefile
+++ b/Makefile
@@ -21,16 +21,17 @@ endif
 
 ifndef DVID_BACKENDS
 DVID_BACKENDS = basholeveldb gbucket
+$(info Backend not specified. Using default value: DVID_BACKENDS="${DVID_BACKENDS}")
 endif
+
 
 export CGO_CFLAGS = -I${CONDA_PREFIX}/include
 export CGO_LDFLAGS = -L${CONDA_PREFIX}/lib -Wl,-rpath,${CONDA_PREFIX}/lib
 
+
 dvid: bin/dvid
 dvid-backup: bin/dvid-backup
 dvid-transfer: bin/dvid-transfer
-
-#FAKE_PARAM := $(shell )
 
 # Compile the program that generates version.go
 bin/dvid-gen-version: cmd/gen-version/main.go

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,22 @@ ifndef GOPATH
 $(error GOPATH must be defined)
 endif
 
+
 ifndef CONDA_PREFIX
-$(error Dvid requires an active conda environment (with dependencies already installed)!)
+define ERRMSG
+
+
+ERROR: Dvid requires an active conda environment, with dependencies already installed.
+       See GUIDE.md for details. Here's the gist of it:
+
+    $$ conda create -n dvid-devel && source activate dvid-devel
+    $$ ./scripts/install-developer-dependencies.sh
+
+
+endef
+$(error ${ERRMSG} )
 endif
+
 
 ifndef DVID_BACKENDS
 DVID_BACKENDS = basholeveldb gbucket


### PR DESCRIPTION
Just some minor improvements to the Makefile output messages. Gives a more descriptive error message if a conda environment isn't active.  Also, displays the default backend if none was specified.

(This is a PR onto `stuart-trial`.)

**Edit:** I also added the Memory Profiling section to `GUIDE.md`, and deleted the old developer instructions from the wiki.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/janelia-flyem/dvid/247)
<!-- Reviewable:end -->
