### PR TITLE
Use new go-cgo package from conda-forge, support conda-4.6

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -25,7 +25,7 @@ $ conda create -n dvidenv -c flyem-forge dvid
 Run:
 
 ```
-$ source activate dvidenv
+$ conda activate dvidenv
 $ dvid about
 ```
 
@@ -37,18 +37,14 @@ Setup
 -----
 
 1. If you are using a bare OS, you will need some essentials before installing anything else: `sudo apt-get install build-essential gcc bzip2`.
-Then Install `conda`.
+Then Install `conda` and enable the `activate` command for your shell (e.g. by running `conda init bash`).
 
-   **Note:** These developer instructions are not yet compatible with conda 4.6 (released in January 2019).
-   Please use conda 4.5, which can be downloaded here:
-
-   - Linux: https://repo.anaconda.com/miniconda/Miniconda2-4.5.12-Linux-x86_64.sh
-   - Mac: https://repo.anaconda.com/miniconda/Miniconda2-4.5.12-MacOSX-x86_64.sh
+   **Note:** These developer instructions assume you are using conda 4.5 or greater.
 
 2. Install `conda-build` and `anaconda-client`:
 
     ```
-    $ source activate base
+    $ conda activate base
     $ conda install conda-build anaconda-client
     ```
     
@@ -71,8 +67,8 @@ Then Install `conda`.
 4. Create a conda environment for dvid development.  Activate it.
 
     ```
-    $ conda create -n dvid-devel
-    $ source activate dvid-devel
+    $ conda create -y -n dvid-devel
+    $ conda activate dvid-devel
     ```
 
 5. Define `GOPATH` and clone the dvid source code into the appropriate subdirectory:
@@ -122,7 +118,7 @@ For each platform (Mac and Linux):
 2. Build the conda package and upload it to the `flyem-forge` channel on `http://anaconda.org`:
 
     ```
-    $ source activate base
+    $ conda activate base
     $ conda build scripts/conda-recipe
     $ anaconda upload -u flyem-forge $(conda info --base)/conda-bld/osx-64/dvid-0.8.20-0.tar.bz2 # Mac
     $ anaconda upload -u flyem-forge $(conda info --base)/conda-bld/linux-64/dvid-0.8.20-0.tar.bz2 # Linux

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,12 @@ ifndef GOPATH
 $(error GOPATH must be defined)
 endif
 
-
 # When building in the context of the conda-recipe,
 # use the "host" PREFIX, (not the "build" env prefix),
 # which is set by conda-build.
 ifdef CONDA_BUILD
     CONDA_PREFIX = ${PREFIX}
 endif
-
 
 ifndef CONDA_PREFIX
     define ERRMSG
@@ -27,6 +25,7 @@ ifndef CONDA_PREFIX
     $(error ${ERRMSG} )
 endif
 
+CONDA_BASE = $(shell conda info --base)
 
 ifndef DVID_BACKENDS
     DVID_BACKENDS = basholeveldb filestore gbucket swift
@@ -62,7 +61,7 @@ bin/dvid-gen-version: cmd/gen-version/main.go
 # .last-build-git-description to force a re-build of server/version.go
 # if the git SHA has changed since the last build
 server/version.go: bin/dvid-gen-version \
-				   $(shell python scripts/record-git-description.py . .last-build-git-description)
+				   $(shell "${CONDA_BASE}/bin/python" scripts/record-git-description.py . .last-build-git-description)
 	bin/dvid-gen-version -o server/version.go
 
 # FIXME: This finds ALL go source files, not just the selection of sources that are needed for dvid.

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ifndef CONDA_PREFIX
     ERROR: Dvid requires an active conda environment, with dependencies already installed.
            See GUIDE.md for details. Here's the gist of it:
     
-        $$ conda create -n dvid-devel && source activate dvid-devel
+        $$ conda create -n dvid-devel && conda activate dvid-devel
         $$ ./scripts/install-developer-dependencies.sh
     
     

--- a/scripts/_install_compiled_dependencies.py
+++ b/scripts/_install_compiled_dependencies.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import datetime
 import tempfile
 import subprocess
@@ -6,6 +7,19 @@ import yaml
 
 print("Determining compiled dependencies...")
 print("(This may take several seconds.)")
+
+nocgo_lines = subprocess.check_output('conda list nocgo', shell=True)
+nocgo_lines = nocgo_lines.decode('utf-8').split('\n')
+nocgo_lines = list(filter(lambda line: line and not line.startswith('#'), nocgo_lines))
+if nocgo_lines:
+    msg = (
+        "*** ERROR: ***\n"
+        "You have go-nocgo (or an associated package) installed in this environment.\n"
+        "That is not compatible with go-cgo, which is necessary for DVID.\n"
+        "Please remove all 'no-cgo' packages, or activate a different environment.\n"
+        "**************\n")
+    sys.stderr.write(msg)
+    sys.exit(1)
 
 # The compiled dependencies are listed in conda-recipe/meta.yaml,
 # in the requirements:build section.

--- a/scripts/conda-recipe/meta.yaml
+++ b/scripts/conda-recipe/meta.yaml
@@ -25,21 +25,40 @@ requirements:
   # are used to build dvid, but are not linked against
   # or incorporated into the executable in any way.
   build:
+
+    ## Note:
+    ##   In conda-forge, there are two different variants of golang:
+    ##     - go-cgo (go built with support for CGO, i.e. C-extensions)
+    ##     - go-nocgo (go built without CGO support)
+    ##
+    ##   For DVID, we need go-cgo.
+    ##   By default, "conda install -c conda-forge go" will install
+    ##   go-nocgo, which is WRONG for us.
+    ##
+    ## The PR that made this change is here:
+    ## - https://github.com/conda-forge/go-feedstock/pull/38#issuecomment-460823214
+    ## With related changes here, too:
+    ## - https://github.com/conda-forge/go-feedstock/pull/43
+
+    ## To install go-cgo, you must actually install two separate packages:
+    ## go-cgo and go-cgo_linux-64 (or go-cgo_osx-64)
+
+    # This package provides the go compiler itself, with CGO support
+    - go-cgo
     
-    # For now, we pull an exact build of the go compiler to avoid
-    # a new issue in the way conda-forge's `go` package is built.
-    # The PR that made this change is here:
-    # - https://github.com/conda-forge/go-feedstock/pull/38#issuecomment-460823214
-    # With related changes here, too:
-    # - https://github.com/conda-forge/go-feedstock/pull/43
-    - go=1.11.3=h8534fd4_1001
-    #- go 1.11.*
+    # This provides the activation script that sets
+    # environment variables needed by golang,
+    # such as GOARCH, GOOS, GOPATH, and GOBIN
+    # (The activation script is automatically called when you activate
+    # a conda environment with 'conda activate my-env')
+    - go-cgo_linux-64 # [linux]
+    - go-cgo_osx-64   # [osx]
 
     # Anaconda's gcc build
     - {{ compiler('c') }}       # [unix]
     - {{ compiler('cxx') }}     # [unix]
     - {{ compiler('fortran') }} # [unix]
-    
+
     - pkg-config
 
   # The 'host' environment is for libraries that

--- a/scripts/install-developer-dependencies.sh
+++ b/scripts/install-developer-dependencies.sh
@@ -18,7 +18,6 @@ cd ${THIS_SCRIPT_DIR}
 ##
 ## Install compiled (conda) dependencies.
 ##
-
 # The following python script requires the 'yaml' python module,
 # which happens to be available in the conda base interpreter,
 # so we use that interpreter to run it.
@@ -28,7 +27,21 @@ ${CONDA_PYTHON} _install_compiled_dependencies.py
 # Some of those dependencies (namely, gcc) may have installed scripts to
 # ${CONDA_PREFIX}/etc/conda/activate.d/
 # so re-activate the current environment to ensure that those scripts have been run.
-source activate ${CONDA_DEFAULT_ENV}
+
+# Old versions of conda sourced an 'activate' script;
+# new versions use the 'conda activate' command
+
+if which activate > /dev/null 2>&1; then
+    source activate ${CONDA_DEFAULT_ENV}
+else
+    # Under conda 4.6, 'conda' isn't available from bash scripts unless
+    # you explicitly define it by sourcing the activate script.
+    # Super-annoying.
+    # https://github.com/conda/conda/issues/7980#issuecomment-441358406
+    CONDA_BASE=$(conda info --root)
+    source ${CONDA_BASE}/etc/profile.d/conda.sh
+    conda activate ${CONDA_DEFAULT_ENV}
+fi
 
 ##
 ## Install go dependencies.


### PR DESCRIPTION
This PR updates the build system to support conda-4.6, and also fixes our go compiler dependency with respect to the changes in the conda-forge `go-cgo` package.

The instructions in our developer `GUIDE.md` work now.  If you are starting from a pre-existing environment, uninstall the following packages before installing the new ones (if you have them):

```
conda remove go
conda remove go-nocgo
conda remove go-nocgo_linux-64
conda remove go-nocgo_osx-64
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/janelia-flyem/dvid/310)
<!-- Reviewable:end -->
