### PR TITLE
conda-recipe: Upgrade librdkafka and lz4-c

### DIFF
--- a/scripts/conda-recipe/conda_build_config.yaml
+++ b/scripts/conda-recipe/conda_build_config.yaml
@@ -11,7 +11,7 @@
 librdkafka:
   - 1.3.0
 lz4_c:
-  - 1.8.3
+  - 1.9.2
 
 pin_run_as_build:
   librdkafka:

--- a/scripts/conda-recipe/meta.yaml
+++ b/scripts/conda-recipe/meta.yaml
@@ -195,10 +195,10 @@ source:
     folder:  src/github.com/boltdb/bolt
 
   # kafka
-  #  NOTE: Using v0.11.6 for now, until we obtain a build of librdkafka 1.0
+  #  NOTE: This is tied to the librdkafka version.
   #        If you change this tag, please also change it in scripts/get-go-dependencies.sh
   - git_url: https://github.com/confluentinc/confluent-kafka-go
-    git_tag: v0.11.6
+    git_tag: v1.3.0
     folder:  src/github.com/confluentinc/confluent-kafka-go
 
   # freecache


### PR DESCRIPTION
It's convenient for me if I can keep these two dependencies in-sync with what my other libraries need.  These are conda-forge's latest versions (`librdkafka 1.4.2` and `lz4-c 1.9.2`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/janelia-flyem/dvid/349)
<!-- Reviewable:end -->
