### PR TITLE
make sure original neuronjson value retained before printing

### DIFF
--- a/datatype/neuronjson/neuronjson.go
+++ b/datatype/neuronjson/neuronjson.go
@@ -1459,8 +1459,8 @@ func (d *Data) storeAndUpdate(ctx *datastore.VersionedCtx, keyStr string, newDat
 		return fmt.Errorf("'bodyid_time' field not allowed")
 	}
 	rcvJSON, _ := json.Marshal(newData)
-	updateJSON(origData, newData, ctx.User, conditionals, replace)
 	origJSON, _ := json.Marshal(origData)
+	updateJSON(origData, newData, ctx.User, conditionals, replace)
 	newJSON, _ := json.Marshal(newData)
 	dvid.Infof("neuronjson %s put by user %q, conditionals %v, replace %t:\nOrig: %s\n Rcv: %s\n New: %s\n",
 		d.DataName(), ctx.User, conditionals, replace, origJSON, rcvJSON, newJSON)


### PR DESCRIPTION
After this fix, the `Orig: <neuronjson>` logged message will accurately reflect the state of the JSON pulled from disk or memory before changes are made. @stuarteberg 