### PR TITLE
disallow labelmap /split endpoint by default

### DIFF
--- a/datatype/labelmap/handlers.go
+++ b/datatype/labelmap/handlers.go
@@ -1761,7 +1761,7 @@ func (d *Data) handleCleave(ctx *datastore.VersionedCtx, w http.ResponseWriter, 
 
 func (d *Data) handleSplit(ctx *datastore.VersionedCtx, w http.ResponseWriter, r *http.Request, parts []string) {
 	// POST <api URL>/node/<UUID>/<data name>/split/<label>[?splitlabel=X]
-	if server.NoLabelmapSplit() {
+	if !server.AllowLabelmapSplit() {
 		server.BadRequest(w, r, "Split endpoint deactivated in this DVID server's configuration.")
 		return
 	}

--- a/datatype/labelmap/labelmap.go
+++ b/datatype/labelmap/labelmap.go
@@ -1363,6 +1363,9 @@ POST <api URL>/node/<UUID>/<data name>/split-supervoxel/<supervoxel>?<options>
 
 POST <api URL>/node/<UUID>/<data name>/split/<label>
 
+	Note: Endpoint deactivated by default. To enable, you must set the
+	AllowLabelmapSplit option to true in the server config TOML file.
+
 	Splits a portion of a label's voxels into a new supervoxel with a new label.  
 	Returns the following JSON:
 

--- a/server/server_local.go
+++ b/server/server_local.go
@@ -341,8 +341,8 @@ func AllowTiming() bool {
 	return tc.Server.AllowTiming
 }
 
-func NoLabelmapSplit() bool {
-	return tc.Server.NoLabelmapSplit
+func AllowLabelmapSplit() bool {
+	return tc.Server.AllowLabelmapSplit
 }
 
 func KafkaServers() []string {
@@ -448,7 +448,7 @@ type localConfig struct {
 	StartWebhook       string // http address that should be called when server is started up.
 	StartJaneliaConfig string // like StartWebhook, but with Janelia-specific behavior
 
-	NoLabelmapSplit bool // If true (default false), prevents labelmap /split endpoint.
+	AllowLabelmapSplit bool // If false (default), prevents access to labelmap /split endpoint.
 
 	IIDGen   string `toml:"instance_id_gen"`
 	IIDStart uint32 `toml:"instance_id_start"`


### PR DESCRIPTION
The labelmap `/split` endpoint is deactivated by default, so to enable it, you must add a `allowLabelmapSplit = true` to the config TOML file. @stuarteberg  