### PR TITLE
add docs useful for LLM in-context learning

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,0 +1,2192 @@
+## Description of the DVID server (from client perspective)
+
+DVID is a versioned, image-oriented dataservice written to support neural reconstruction, analysis 
+and visualization efforts at HHMI Janelia Research Center. It provides storage with branched 
+versioning of a variety of data focused on Connectomics.
+
+There are a couple of concepts essential to understanding how DVID works. First, data consists
+of named instances of various datatypes. Each datatype provides a variety of functions through
+a REST HTTP API. The HTTP API for each datatype will be provided below. There can be many 
+different data instances of a datatype. For example, there could be instances 
+"segmentation_meshes" and "segmentation_skeletons" of the "keyvalue" datatype. Each of those 
+instances could hold billions of key-value pairs where the key is an integer neuron (or body) ID and
+the value is a byte blob that could be a mesh OBJ file (for "segmentation_meshes") or a SWC format
+file (for "segmentation_skeletons").
+
+Second, data is committed across versions similar to how git stores files at different versions. 
+For DVID, a version is identified by a hexadecimal UUID. DVID supports branched versioning so all
+the versions form a Directed Acyclic Graph (DAG). Requests for data typically require a UUID to 
+determine a version as well as a unique name to determine the data instance. An example would
+be the version b8a54214d9fd40ada115aaa8f0d78b2f and data instance "segmentation_meshes".
+UUIDs can be truncated as long as the prefix is sufficient to unambiguously determine the version.
+Instead of a UUID, a special string ":master" or ":master^1" can be used to determine a version.
+The string ":master" refers to the HEAD (or leaf) of the master branch while ":master^1" refers
+to the version before the HEAD.
+
+For a given data instance X and UUID V, most HTTP endpoints typically are of the form 
+"http://my.dvid.com/api/node/V/X/..." where the ellipses could be replaced by a series of 
+slash-separated parameters.  Many endpoints also have query strings for specifying options.
+
+The following HTTP API endpoints are a subset of the actual endpoints pertinent to LLM usage.
+In general, LLMs should only perform reads and not use the POST method.
+
+### Server-level HTTP API
+
+These are HTTP endpoints that provide server-level information.
+
+ GET  /api/help
+
+	The current page that lists all general and type-specific commands/HTTP API.
+
+ GET  /api/help/{typename}
+
+	Returns help for the given datatype.
+
+ GET  /api/load
+
+	Returns a JSON of server load statistics.
+
+ GET  /api/storage
+
+ 	Returns a JSON object for each backend store where the key is the backend store name.
+	The store object has local instance ID keys with the following object value:
+
+	{
+		"Name": "grayscale",
+		"DataType": "uint8blk",
+		"DataUUID": ...,
+		"RootUUID": ...,  // this is the UUID of this data's root
+		"Bytes": ...
+	}
+
+ GET  /api/heartbeat[?u=]
+
+	Preferred method to test whether server is alive.  If a username is provided, the
+	time it takes to respond to the request (including transmission to remote client)
+	is recorded.  A compilation of user latencies is available through the 
+	/api/user-latencies endpoint.
+
+GET  /api/server/info
+
+	Returns JSON for server properties.
+
+GET  /api/server/note 
+
+	Returns any value of [server.note] from the configuration TOML.
+
+GET  /api/server/config 
+
+	Returns the raw content of the configuration TOML.
+
+GET  /api/server/types
+
+	Returns JSON with the datatypes of currently stored data instances.  Datatypes are represented
+	by a name and the URL of the reference implementation.  To see all possible datatypes, i.e., the
+	list of compiled datatypes, use the "compiled-types" endpoint.
+
+GET  /api/server/compiled-types
+
+ 	Returns JSON of all possible datatypes for this server, i.e., the list of compiled datatypes.
+
+
+### Repository-level HTTP API
+
+These are HTTP endpoints that provide information for a repository.
+
+ GET  /api/repos/info
+
+	Returns JSON for the repositories under management by this server.
+	Note that any versioned properties for image-based data instances (e.g., extents) 
+	will be drawn from the leaf of the master branch.
+
+ HEAD /api/repo/{uuid}
+
+	Returns 200 if a repo with given UUID is available.
+
+ GET  /api/repo/{uuid}/info
+
+	Returns JSON for just the repository with given root UUID.  The UUID string can be
+	shortened as long as it is uniquely identifiable across the managed repositories.
+	Note that any versioned properties for image-based data instances (e.g., extents) 
+	will be drawn from the leaf of the master branch.
+
+  GET /api/repo/{uuid}/log
+ POST /api/repo/{uuid}/log
+
+	GETs or POSTs log data to the repo with given UUID.  The get or post body should 
+	be JSON of the following format: 
+
+	{ "log": [ "provenance data...", "provenance data...", ...] }
+
+	The log is a list of strings that will be appended to the repo's log.  They should be
+	descriptions for the entire repo and not just one node.  For particular versions, use
+	node-level logging (below).
+
+  GET /api/repo/{uuid}/branch-versions/{branch name}
+
+	Returns a JSON list of version UUIDs for the given branch name, starting with the
+	current leaf and working back to the root.  Use "master" for the default branch.
+
+	If a repository predates the introduction of branch names and has multiple paths
+	for the given branch name, the endpoint will return an Bad Request Error (400).
+
+
+### Datatype-level HTTP API
+
+Each datatype has its own set of HTTP endpoints, and some endpoints are similar across many
+different datatypes. For example, the "http://my.dvid.com/api/node/V/X/info" returns
+metadata for the data instance X that has some version V. The version UUID is necessary
+because one DVID server could hold multiple repositories, each with sets of unique UUIDs.
+
+### Important Datatypes
+
+keyvalue: a simple key-value pair store that can be used as a versioned file system.
+
+neuronjson: similar to a keyvalue but the value is a JSON object tailored to hold properties for a neuron.
+
+uint8blk: 3d grayscale volumes.
+
+labelmap: 64-bit label 3d volumes, including multi-scale support and sparse volume operations.
+
+annotation: 3d points that can be accessed by associated label, tags, or spatial coordinate.
+
+roi: regions of interest represented via a coarse subdivision of space using block indices.
+
+
+### Keyvalue Datatype HTTP API
+
+GET  <api URL>/node/<UUID>/<data name>/help
+
+	Returns data-specific help message.
+
+
+GET  <api URL>/node/<UUID>/<data name>/info
+
+	Retrieves data properties.
+
+	Example: 
+
+	GET <api URL>/node/3f8c/stuff/info
+
+	Returns JSON with configuration settings.
+
+	Arguments:
+
+	UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+	data name     Name of keyvalue data instance.
+
+GET <api URL>/node/<UUID>/<data name>/tags
+
+	GET retrieves JSON of tags for this instance.
+
+	{ "tag1": "anything you want", "tag2": "something else" }
+
+			   	
+GET  <api URL>/node/<UUID>/<data name>/keys
+
+	Returns all keys for this data instance in JSON format:
+
+	[key1, key2, ...]
+
+GET  <api URL>/node/<UUID>/<data name>/keyrange/<key1>/<key2>
+
+	Returns all keys between 'key1' and 'key2' for this data instance in JSON format:
+
+	[key1, key2, ...]
+
+	Arguments:
+
+	UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+	data name     Name of keyvalue data instance.
+	key1          Lexicographically lowest alphanumeric key in range.
+	key2          Lexicographically highest alphanumeric key in range.
+
+GET  <api URL>/node/<UUID>/<data name>/keyrangevalues/<key1>/<key2>?<options>
+
+	This has the same response as the GET /keyvalues endpoint but a different way of
+	specifying the keys.  In this endpoint, you specify a range of keys.  In the other
+	endpoint, you must explicitly send the keys in a GET payload, which may not be
+	fully supported.
+
+	Note that this endpoint streams data to the requester, which prevents setting HTTP
+	status to error if the streaming has already started.  Instead, malformed output
+	will inform the requester of an error.
+
+	Response types:
+
+	1) json (values are expected to be valid JSON or an error is returned)
+
+		{
+			"key1": value1,
+			"key2": value2,
+			...
+		}
+
+	2) tar
+
+		A tarfile is returned with each keys specifying the file names and
+		values as the file bytes.
+
+	3) protobuf3
+	
+		KeyValue data needs to be serialized in a format defined by the following 
+		protobuf3 definitions:
+
+		message KeyValue {
+			string key = 1;
+			bytes value = 2;
+		}
+
+		message KeyValues {
+			repeated KeyValue kvs = 1;
+		}
+
+	Arguments:
+
+	UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+	data name     Name of keyvalue data instance.
+	key1          Lexicographically lowest alphanumeric key in range.
+	key2          Lexicographically highest alphanumeric key in range.
+
+	GET Query-string Options (only one of these allowed):
+
+	json        If set to "true", the response will be JSON as above and the values must
+				  be valid JSON or an error will be returned.
+	tar			If set to "true", the response will be a tarfile with keys as file names.
+	protobuf	Default, or can be set to "true". Response will be protobuf KeyValues response
+
+	Additional query option:
+
+	check		If json=true, setting check=false will tell server to trust that the
+				  values will be valid JSON instead of parsing it as a check.
+
+
+GET  <api URL>/node/<UUID>/<data name>/key/<key>
+HEAD <api URL>/node/<UUID>/<data name>/key/<key> 
+
+	Performs operations on a key-value pair depending on the HTTP verb.  
+
+	Example: 
+
+	GET <api URL>/node/3f8c/stuff/key/myfile.dat
+
+	Returns the data associated with the key "myfile.dat" of instance "stuff" in version
+	node 3f8c.
+
+	The "Content-type" of the HTTP response (and usually the request) are
+	"application/octet-stream" for arbitrary binary data.
+
+	For HEAD returns:
+	200 (OK) if a sparse volume of the given label exists within any optional bounds.
+	404 (File not Found) if there is no sparse volume for the given label within any optional bounds.
+
+	Arguments:
+
+	UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+	data name     Name of keyvalue data instance.
+	key           An alphanumeric key.
+	
+	POSTs will be logged as a Kafka JSON message with the following format:
+	{ 
+		"Action": "postkv",
+		"Key": <key>,
+		"Bytes": <number of bytes in data>,
+		"UUID": <UUID on which POST was done>
+	}
+
+GET <api URL>/node/<UUID>/<data name>/keyvalues[?jsontar=true]
+
+	Allows batch query of data. 
+
+	KeyValue data needs to be serialized in a format defined by the following protobuf3 definitions:
+
+		message KeyValue {
+			string key = 1;
+			bytes value = 2;
+		}
+
+		message Keys {
+			repeated string keys = 1;
+		}
+		
+		message KeyValues {
+			repeated KeyValue kvs = 1;
+		}
+	
+	For GET, the query body must include a Keys serialization and a KeyValues serialization is
+	returned.  If a key is not found, it is included in return but with nil value (0 bytes or "{}").
+
+	Arguments:
+
+	UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+	data name     Name of keyvalue data instance.
+
+	GET Query-string Options (only one of these allowed):
+
+	json        If set true, returns JSON (see below) where values must be valid JSON.
+	jsontar		If set to any value for GET, query body must be JSON array of string keys
+				and the returned data will be a tarfile with keys as file names.
+
+	Response types:
+
+	1) json (values are expected to be valid JSON or an error is returned)
+
+		{
+			"key1": value1,
+			"key2": value2,
+			...
+			"bad key": {}
+		}
+
+		If key wasn't found, the "{}" value is returned.
+
+	2) tar
+
+		A tarfile is returned with each keys specifying the file names and
+		values as the file bytes.
+
+	3) protobuf3
+	
+		KeyValue data needs to be serialized in a format defined by the following 
+		protobuf3 definitions:
+
+		message KeyValue {
+			string key = 1;
+			bytes value = 2;
+		}
+
+		message KeyValues {
+			repeated KeyValue kvs = 1;
+		}
+
+	Arguments:
+
+	UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+	data name     Name of keyvalue data instance.
+	key1          Lexicographically lowest alphanumeric key in range.
+	key2          Lexicographically highest alphanumeric key in range.
+
+	GET Query-string Options (only one of these allowed):
+
+	json        If set to "true", the response will be JSON as above and the values must
+					be valid JSON or an error will be returned.
+	tar			If set to "true", the response will be a tarfile with keys as file names.
+	protobuf	If set to "true", the response will be protobuf KeyValues response
+
+	check		If json=true, setting check=false will tell server to trust that the
+					values will be valid JSON instead of parsing it as a check.
+
+GET <api URL>/node/<UUID>/<data name>/mutations[?queryopts]
+
+	Returns JSON list of the successfully completed mutations for the given version 
+	for this data instance.  Each mutation record format is equivalent to the JSON 
+	provided to the Kafka mutation log.  For example, a POST mutation would be:
+
+	{
+		"Action": "postkv",
+		"Key": "20",
+		"Bytes": 4039,
+		"UUID": "28841c8277e044a7b187dda03e18da13",
+		"Timestamp": <string>
+	}
+
+	Query-string options:
+
+		userid: Limit returned mutations to the given User ID.  Note that
+				this should be distinguished from the "u" query string which
+				is the requester's User ID (not necessarily the same as the
+				User ID whose mutations are being requested).
+
+GET <api URL>/node/<UUID>/<data name>/mutations-range/<beg>/<end>?rangefmt=<format>
+
+	Returns JSON list of the successfully completed mutations across a given
+	range. The range format of parameters <beg> and <end> is specified by the 
+	value of the "rangefmt" query string:
+
+		default:  If no query string is given, the range is in the form of
+					version UUIDs.
+
+		--- The following are not yet implemented ---
+		"mutids":  The range is in the form of mutation IDs (uint64).
+
+		"timestamps":  The range is in the form of RFC 3339 timestamps.
+
+### neuronjson Datatype HTTP API
+
+GET  <api URL>/node/<UUID>/<data name>/help
+
+	Returns data-specific help message.
+
+
+GET  <api URL>/node/<UUID>/<data name>/info
+
+	Retrieves data properties.
+
+	Example: 
+
+	GET <api URL>/node/3f8c/stuff/info
+
+	Returns JSON with configuration settings.
+
+	Arguments:
+
+	UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+	data name     Name of neuronjson data instance.
+
+GET <api URL>/node/<UUID>/<data name>/tags
+
+	GET retrieves JSON of tags for this instance.
+
+	{ "tag1": "anything you want", "tag2": "something else" }
+
+
+GET  <api URL>/node/<UUID>/<data name>/<schema type>
+HEAD <api URL>/node/<UUID>/<data name>/<schema type> 
+
+	Performs operations on metadata schema depending on the HTTP verb.  
+	If the "json_schema" type is POSTed, it will be used to validate
+	future writes of neuron annotations via POST /key, /keyvalues, etc.
+
+	Example: 
+
+	GET <api URL>/node/3f8c/neuron_annotations/json_schema
+
+	Returns any JSON schema for validation stored for version node 3f8c.
+
+	The "Content-type" of the HTTP response (and usually the request) are "application/json".
+
+	Arguments:
+
+	UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+	data name     Name of keyvalue data instance.
+	schema type	  One of "json_schema" (validation), "schema" (neutu/neu3), "schema_batch" (neutu/neu3)
+				
+GET  <api URL>/node/<UUID>/<data name>/all[?query-options]
+
+	Returns a list of all JSON annotations
+
+	GET Query-string Options:
+
+	show		If "user", shows *_user fields.
+				If "time", shows *_time fields.
+				If "all", shows both *_user and *_time fields.
+				If unset (default), shows neither *_user or *_time fields.
+	
+	fields      Limit return to this list of field names separated by commas.
+                Example: ?fields=type,instance
+				Note that the above "show" query string still applies to the fields.
+			
+GET  <api URL>/node/<UUID>/<data name>/keys
+
+	Returns all keys for this data instance in JSON format:
+
+	[key1, key2, ...]
+
+GET  <api URL>/node/<UUID>/<data name>/fields[?counts=true]
+
+	By default, returns all field names in annotations for the given version:
+
+	["field1", "field2", ...]
+
+	If the query string "counts=true" is set, the response will be a JSON object:
+
+	{"field1": count1, "field2": count2, ...}
+
+GET  <api URL>/node/<UUID>/<data name>/fieldtimes
+
+	Returns the RFC3339 timestamps for each field in the most recent version:
+
+	{"field1": "timestamp1", "field2": "timestamp2", ...}
+
+GET  <api URL>/node/<UUID>/<data name>/keyrange/<key1>/<key2>
+
+	Returns all keys between 'key1' and 'key2' for this data instance in JSON format:
+
+	[key1, key2, ...]
+
+	Arguments:
+
+	UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+	data name     Name of neuronjson data instance.
+	key1          Lexicographically lowest alphanumeric key in range.
+	key2          Lexicographically highest alphanumeric key in range.
+
+GET  <api URL>/node/<UUID>/<data name>/keyrangevalues/<key1>/<key2>?<options>
+
+	This has the same response as the GET /keyvalues endpoint but a different way of
+	specifying the keys.  In this endpoint, you specify a range of keys.  In the other
+	endpoint, you must explicitly send the keys in a GET payload, which may not be
+	fully supported.
+
+	Note that this endpoint streams data to the requester, which prevents setting HTTP
+	status to error if the streaming has already started.  Instead, malformed output
+	will inform the requester of an error.
+
+	Response types:
+
+	1) json (values are expected to be valid JSON or an error is returned)
+
+		{
+			"key1": value1,
+			"key2": value2,
+			...
+		}
+
+	2) tar
+
+		A tarfile is returned with each keys specifying the file names and
+		values as the file bytes.
+
+	3) protobuf3
+	
+		neuronjson data needs to be serialized in a format defined by the following 
+		protobuf3 definitions:
+
+		message KeyValue {
+			string key = 1;
+			bytes value = 2;
+		}
+
+		message KeyValues {
+			repeated KeyValue kvs = 1;
+		}
+
+	Arguments:
+
+	UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+	data name     Name of neuronjson data instance.
+	key1          Lexicographically lowest alphanumeric key in range.
+	key2          Lexicographically highest alphanumeric key in range.
+
+	Query-string Options (only one of these allowed):
+
+	json        If set to "true", the response will be JSON as above and the values must
+				  be valid JSON or an error will be returned.
+	tar			If set to "true", the response will be a tarfile with keys as file names.
+	protobuf	Default, or can be set to "true". Response will be protobuf KeyValues response
+
+	Additional query option:
+
+	check		If json=true, setting check=false will tell server to trust that the
+				  values will be valid JSON instead of parsing it as a check.
+
+	show		If "user", shows *_user fields.
+				If "time", shows *_time fields.
+				If "all", shows both *_user and *_time fields.
+				If unset (default), shows neither *_user or *_time fields.
+	
+	fields      Limit return to this list of field names separated by commas.
+                Example: ?fields=type,instance
+				Note that the above "show" query string still applies to the fields.
+
+
+GET  <api URL>/node/<UUID>/<data name>/key/<key>[?query-options]
+
+	For a given neuron id key, returns a value depending on the options.  
+
+	Example: 
+
+	GET <api URL>/node/3f8c/stuff/key/myfile.dat
+
+	Returns the data associated with the key "myfile.dat" of instance "stuff" in version
+	node 3f8c.
+
+	The "Content-type" of the HTTP response (and usually the request) are
+	"application/octet-stream" for arbitrary binary data.
+
+	Arguments:
+
+	UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+	data name     Name of neuronjson data instance.
+	key           The uint64 of a neuron identifier
+
+	GET Query-string Options:
+
+	show		If "user", shows *_user fields.
+				If "time", shows *_time fields.
+				If "all", shows both *_user and *_time fields.
+				If unset (default), shows neither *_user or *_time fields.
+	
+	fields      Limit return to this list of field names separated by commas.
+                Example: ?fields=type,instance
+				Note that the above "show" query string still applies to the fields.
+
+
+HEAD   <api URL>/node/<UUID>/<data name>/key/<key> 
+
+	Performs operations on a key-value pair depending on the HTTP verb.  
+
+	For HEAD returns:
+	200 (OK) if a sparse volume of the given label exists within any optional bounds.
+	404 (File not Found) if there is no sparse volume for the given label within any optional bounds.
+
+	Arguments:
+
+	UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+	data name     Name of neuronjson data instance.
+	key           The uint64 of a neuron identifier
+				
+
+GET <api URL>/node/<UUID>/<data name>/keyvalues[?query-options]
+
+	Allows batch query of data. 
+
+	Unless using one of the JSON query options listed below, requested keys and
+	returned neuronjson data is serialized in a format defined by the following 
+	protobuf3 definitions:
+
+		message KeyValue {
+			string key = 1;
+			bytes value = 2;
+		}
+
+		message Keys {
+			repeated string keys = 1;
+		}
+		
+		message KeyValues {
+			repeated KeyValue kvs = 1;
+		}
+	
+	The query body must include a Keys serialization and a KeyValues serialization is
+	returned.
+
+	Arguments:
+
+	UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+	data name     Name of neuronjson data instance.
+
+	Query-string Options:
+
+	show		If "user", shows *_user fields.
+				If "time", shows *_time fields.
+				If "all", shows both *_user and *_time fields.
+				If unset (default), shows neither *_user or *_time fields.
+	
+	fields      Limit return to this list of field names separated by commas.
+                Example: ?fields=type,instance
+				Note that the above "show" query string still applies to the fields.
+
+	Only one of the following are allowed in a single query:
+
+	json        If true (default false), query body must be JSON array of keys and returns JSON.
+	jsontar		If set to any value for GET, query body must be JSON array of string keys
+				  and the returned data will be a tarfile with keys as file names.
+	protobuf	If set to "true", the response will be protobuf KeyValues response
+
+	Response types:
+
+	1) json (values are expected to be valid JSON or an error is returned)
+
+		{
+			"key1": value1,
+			"key2": value2,
+			...
+		}
+
+	2) tar
+
+		A tarfile is returned with each keys specifying the file names and
+		values as the file bytes.
+
+	3) protobuf3
+	
+		KeyValue data needs to be serialized in a format defined by the following 
+		protobuf3 definitions:
+
+		message KeyValue {
+			string key = 1;
+			bytes value = 2;
+		}
+
+		message KeyValues {
+			repeated KeyValue kvs = 1;
+		}
+
+
+GET <api URL>/node/<UUID>/<data name>/query[?show=...]
+POST <api URL>/node/<UUID>/<data name>/query[?show=...]
+
+	Both GET and POST methods are permitted to launch queries, however the
+	POST method is deprecated because it will be blocked for committed versions.
+	The JSON query format uses field names as the keys, and desired values.
+	Example:
+	{ "bodyid": 23, "hemilineage": "0B", ... }
+	Each field value must be true, i.e., the conditions are ANDed together.
+
+	If a list of queries (JSON object per query) is POSTed, the results for each query are ORed
+	together with duplicate annotations removed.
+
+	A JSON list of objects that matches the query is returned in ascending order of body ID.
+
+	Query fields can include two special types of values:
+	1. Regular expressions: a string value that starts with "re/" is treated as a regex with
+	   the remainder of the string being the regex.  The regex is anchored to the beginning.
+	2. Field existence: a string value that starts with "exists/" checks if a field exists.
+	   If "exists/0" is specified, the field must not exist or be set to null.  If "exists/1" 
+	   is specified, the field must exist.
+
+	Arguments:
+
+	UUID 		Hexadecimal string with enough characters to uniquely identify a version node.
+	data name	Name of neuronjson data instance.
+
+	GET Query-string Options:
+
+	onlyid		If true (false by default), will only return a list of body ids that match.
+
+	show		If "user", shows *_user fields.
+				If "time", shows *_time fields.
+				If "all", shows both *_user and *_time fields.
+				If unset (default), shows neither *_user or *_time fields.
+
+	fields      Limit return to this list of field names separated by commas.
+                Example: ?fields=type,instance
+				Note that the above "show" query string still applies to the fields.
+
+### uint8blk Datatype HTTP API
+
+GET  <api URL>/node/<UUID>/<data name>/help
+
+	Returns data-specific help message.
+
+
+GET  <api URL>/node/<UUID>/<data name>/info
+
+    Retrieves or DVID-specific data properties for these voxels.
+
+    Example: 
+
+    GET <api URL>/node/3f8c/grayscale/info
+
+    Returns JSON with configuration settings that include location in DVID space and
+    min/max block indices.
+
+    Arguments:
+
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of voxels data.
+
+
+GET  <api URL>/node/<UUID>/<data name>/metadata
+
+	Retrieves a JSON schema (application/vnd.dvid-nd-data+json) that describes the layout
+	of bytes returned for n-d images.
+
+GET <api URL>/node/<UUID>/<data name>/rawkey?x=<block x>&y=<block y>&z=<block z>
+
+    Returns JSON describing hex-encoded binary key used to store a block of data at the given block coordinate:
+
+    {
+        "Key": "FF3801AD78BBD4829A3"
+    }
+
+    The query options for block x, y, and z must be supplied or this request will return an error.
+
+GET  <api URL>/node/<UUID>/<data name>/isotropic/<dims>/<size>/<offset>[/<format>][?queryopts]
+
+    Retrieves either 2d images (PNG by default) or 3d binary data, depending on the dims parameter. 
+	If the underlying data is float32, then the little-endian four byte format is written as RGBA.
+    The 3d binary data response has "Content-type" set to "application/octet-stream" and is an array of 
+    voxel values in ZYX order (X iterates most rapidly).
+
+    Example: 
+
+    GET <api URL>/node/3f8c/grayscale/isotropic/0_1/512_256/0_0_100/jpg:80
+
+    Returns an isotropic XY slice (0th and 1st dimensions) with width (x) of 512 voxels and
+    height (y) of 256 voxels with offset (0,0,100) in JPG format with quality 80.
+    Additional processing is applied based on voxel resolutions to make sure the retrieved image 
+    has isotropic pixels.  For example, if an XZ image is requested and the image volume has 
+    X resolution 3 nm and Z resolution 40 nm, the returned image's height will be magnified 40/3
+    relative to the raw data.
+    The example offset assumes the "grayscale" data in version node "3f8c" is 3d.
+    The "Content-type" of the HTTP response should agree with the requested format.
+    For example, returned PNGs will have "Content-type" of "image/png", and returned
+    nD data will be "application/octet-stream".
+
+    Arguments:
+
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of data to add.
+    dims          The axes of data extraction in form "i_j_k,..."  Example: "0_2" can be XZ.
+                    Slice strings ("xy", "xz", or "yz") are also accepted.
+    size          Size in voxels along each dimension specified in <dims>.
+    offset        Gives coordinate of first voxel using dimensionality of data.
+    format        Valid formats depend on the dimensionality of the request and formats
+                    available in server implementation.
+                  2D: "png", "jpg" (default: "png")
+                    jpg allows lossy quality setting, e.g., "jpg:80"
+                  nD: uses default "octet-stream".
+
+    Query-string Options:
+
+    throttle      Only works for 3d data requests.  If "true", makes sure only N compute-intense operation 
+                    (all API calls that can be throttled) are handled.  If the server can't initiate the API 
+                    call right away, a 503 (Service Unavailable) status code is returned.
+
+GET  <api URL>/node/<UUID>/<data name>/specificblocks[?queryopts]
+
+    Retrieves blocks corresponding to those specified in the query string.  This interface
+    is useful if the blocks retrieved are not consecutive or if the backend in non ordered.
+
+    TODO: enable arbitrary compression to be specified
+
+    Example: 
+
+    GET <api URL>/node/3f8c/grayscale/specificblocks?blocks=x1,y1,z2,x2,y2,z2,x3,y3,z3
+	
+	This will fetch blocks at position (x1,y1,z1), (x2,y2,z2), and (x3,y3,z3).
+	The returned byte stream has a list of blocks with a leading block 
+	coordinate (3 x int32) plus int32 giving the # of bytes in this block, and  then the 
+	bytes for the value.  If blocks are unset within the span, they will not appear in the stream,
+	so the returned data will be equal to or less than spanX blocks worth of data.  
+
+    The returned data format has the following format where int32 is in little endian and the bytes of
+    block data have been compressed in JPEG format.
+
+        int32  Block 1 coordinate X (Note that this may not be starting block coordinate if it is unset.)
+        int32  Block 1 coordinate Y
+        int32  Block 1 coordinate Z
+        int32  # bytes for first block (N1)
+        byte0  Bytes of block data in jpeg-compressed format.
+        byte1
+        ...
+        byteN1
+
+        int32  Block 2 coordinate X
+        int32  Block 2 coordinate Y
+        int32  Block 2 coordinate Z
+        int32  # bytes for second block (N2)
+        byte0  Bytes of block data in jpeg-compressed format.
+        byte1
+        ...
+        byteN2
+
+        ...
+
+    If no data is available for given block span, nothing is returned.
+
+    Arguments:
+
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of data to add.
+
+    Query-string Options:
+
+    compression   Allows retrieval of block data in default storage or as "uncompressed".
+    blocks	  x,y,z... block string
+    prefetch	  ("on" or "true") Do not actually send data, non-blocking (default "off")
+
+
+GET  <api URL>/node/<UUID>/<data name>/subvolblocks/<size>/<offset>[?queryopts]
+
+    Retrieves blocks corresponding to the extents specified by the size and offset.  The
+    subvolume request must be block aligned.  This is the most server-efficient way of
+    retrieving imagelblk data, where data read from the underlying storage engine
+    is written directly to the HTTP connection.
+
+    Example: 
+
+    GET <api URL>/node/3f8c/segmentation/subvolblocks/64_64_64/0_0_0
+
+	If block size is 32x32x32, this call retrieves up to 8 blocks where the first potential
+	block is at 0, 0, 0.  The returned byte stream has a list of blocks with a leading block 
+	coordinate (3 x int32) plus int32 giving the # of bytes in this block, and  then the 
+	bytes for the value.  If blocks are unset within the span, they will not appear in the stream,
+	so the returned data will be equal to or less than spanX blocks worth of data.  
+
+    The returned data format has the following format where int32 is in little endian and the bytes of
+    block data have been compressed in JPEG format.
+
+        int32  Block 1 coordinate X (Note that this may not be starting block coordinate if it is unset.)
+        int32  Block 1 coordinate Y
+        int32  Block 1 coordinate Z
+        int32  # bytes for first block (N1)
+        byte0  Bytes of block data in jpeg-compressed format.
+        byte1
+        ...
+        byteN1
+
+        int32  Block 2 coordinate X
+        int32  Block 2 coordinate Y
+        int32  Block 2 coordinate Z
+        int32  # bytes for second block (N2)
+        byte0  Bytes of block data in jpeg-compressed format.
+        byte1
+        ...
+        byteN2
+
+        ...
+
+    If no data is available for given block span, nothing is returned.
+
+    Arguments:
+
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of data to add.
+    size          Size in voxels along each dimension specified in <dims>.
+    offset        Gives coordinate of first voxel using dimensionality of data.
+
+    Query-string Options:
+
+	compression   Allows retrieval of block data in "jpeg" (default) or "uncompressed". 
+					Note that if the data isn't stored as JPEG, it cannot be requested. 
+    throttle      If "true", makes sure only N compute-intense operation (all API calls that can be throttled) 
+                    are handled.  If the server can't initiate the API call right away, a 503 (Service Unavailable) 
+                    status code is returned.
+
+
+GET  <api URL>/node/<UUID>/<data name>/raw/<dims>/<size>/<offset>[/<format>][?queryopts]
+
+    Retrieves either 2d images (PNG by default) or 3d binary data, depending on the dims parameter.
+	If the underlying data is float32, then the little-endian four byte format is written as RGBA.
+    The 3d binary data response has "Content-type" set to "application/octet-stream" and is an array of 
+    voxel values in ZYX order (X iterates most rapidly).
+
+    Example: 
+
+    GET <api URL>/node/3f8c/grayscale/raw/0_1/512_256/0_0_100/jpg:80
+
+    Returns a raw XY slice (0th and 1st dimensions) with width (x) of 512 voxels and
+    height (y) of 256 voxels with offset (0,0,100) in JPG format with quality 80.
+    By "raw", we mean that no additional processing is applied based on voxel
+    resolutions to make sure the retrieved image has isotropic pixels.
+    The example offset assumes the "grayscale" data in version node "3f8c" is 3d.
+    The "Content-type" of the HTTP response should agree with the requested format.
+    For example, returned PNGs will have "Content-type" of "image/png", and returned
+    nD data will be "application/octet-stream". 
+
+    Arguments:
+
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of data to add.
+    dims          The axes of data extraction in form "i_j_k,..."  
+                    Slice strings ("xy", "xz", or "yz") are also accepted.
+                    Example: "0_2" is XZ, and "0_1_2" is a 3d subvolume.
+    size          Size in voxels along each dimension specified in <dims>.
+    offset        Gives coordinate of first voxel using dimensionality of data.
+    format        Valid formats depend on the dimensionality of the request and formats
+                    available in server implementation.
+                  2D: "png", "jpg" (default: "png")
+                    jpg allows lossy quality setting, e.g., "jpg:80"
+                  3D: uses default "octet-stream".
+
+    Query-string Options:
+
+    roi           Name of roi data instance used to mask the requested data.
+    attenuation   For attenuation n, this reduces the intensity of voxels outside ROI by 2^n.
+                  Valid range is n = 1 to n = 7.  Currently only implemented for 8-bit voxels.
+                  Default is to zero out voxels outside ROI.
+    throttle      Only works for 3d data requests.  If "true", makes sure only N compute-intense operation 
+                    (all API calls that can be throttled) are handled.  If the server can't initiate the API 
+                    call right away, a 503 (Service Unavailable) status code is returned.
+
+GET  <api URL>/node/<UUID>/<data name>/arb/<top left>/<top right>/<bottom left>/<res>[/<format>][?queryopts]
+
+    Retrieves non-orthogonal (arbitrarily oriented planar) image data of named 3d data 
+    within a version node.  Returns an image where the top left pixel corresponds to the
+    real world coordinate (not in voxel space but in space defined by resolution, e.g.,
+    nanometer space).  The real world coordinates are specified in  "x_y_z" format, e.g., "20.3_11.8_109.4".
+    The resolution is used to determine the # pixels in the returned image.
+
+    Example: 
+
+    GET <api URL>/node/3f8c/grayscale/arb/100.2_90_80.7/200.2_90_80.7/100.2_190.0_80.7/10.0/jpg:80
+
+    Arguments:
+
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of data to add.
+    top left      Real world coordinate (in nanometers) of top left pixel in returned image.
+    top right     Real world coordinate of top right pixel.
+    bottom left   Real world coordinate of bottom left pixel.
+    res           The resolution/pixel that is used to calculate the returned image size in pixels.
+    format        "png", "jpg" (default: "png")  
+                    jpg allows lossy quality setting, e.g., "jpg:80"
+
+    Query-string Options:
+
+    throttle      If "true", makes sure only N compute-intense operation 
+                    (all API calls that can be throttled) are handled.  If the server can't initiate the API 
+                    call right away, a 503 (Service Unavailable) status code is returned.
+
+ GET <api URL>/node/<UUID>/<data name>/blocks/<block coord>/<spanX>
+
+    Retrieves "spanX" blocks of uncompressed voxel data along X starting from given block coordinate.
+
+    Example: 
+
+    GET <api URL>/node/3f8c/grayscale/blocks/10_20_30/8
+
+    Returns blocks where first block has given block coordinate and number
+    of blocks returned along x axis is "spanX".  The data is sent in the following format:
+
+    <block 0 byte array>
+    <block 1 byte array>
+    ... 
+    <block N byte array>
+
+    Each byte array iterates in X, then Y, then Z for that block.
+
+    Arguments:
+
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of data to add.
+    block coord   The block coordinate of the first block in X_Y_Z format.  Block coordinates
+                  can be derived from voxel coordinates by dividing voxel coordinates by
+                  the block size for a data type.
+
+### labelmap Datatype HTTP API
+
+GET  <api URL>/node/<UUID>/<data name>/help
+
+	Returns data-specific help message.
+
+
+GET  <api URL>/node/<UUID>/<data name>/info
+
+    Retrieves or puts DVID-specific data properties for these voxels.
+
+    Example: 
+
+    GET <api URL>/node/3f8c/segmentation/info
+
+    Returns or posts JSON of configuration settings with the following optional fields:
+
+     "BlockSize"        Size in pixels  (default: 64,64,64 and should be multiples of 16)
+     "VoxelSize"        Resolution of voxels (default: 8.0,8.0,8.0)
+     "VoxelUnits"       Resolution units (default: "nanometers")
+	 "MinPoint"         Minimum voxel coordinate as 3d point
+	 "MaxPoint"         Maximum voxel coordinate as 3d point
+	 "GridStore"        Store identifier in TOML config file that specifies precomputed store.
+	 "MaxDownresLevel"  The maximum down-res level supported.  Each down-res is factor of 2.
+
+    Arguments:
+
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of labelmap instance.
+
+GET <api URL>/node/<UUID>/<data name>/tags
+
+	GET retrieves JSON of tags for this instance.
+
+	{ "tag1": "anything you want", "tag2": "something else" }
+
+			   
+GET  <api URL>/node/<UUID>/<data name>/metadata
+
+	Retrieves a JSON schema (application/vnd.dvid-nd-data+json) that describes the layout
+	of bytes returned for n-d images.
+
+
+GET  <api URL>/node/<UUID>/<data name>/specificblocks[?queryopts]
+
+    Retrieves blocks corresponding to those specified in the query string.  This interface
+    is useful if the blocks retrieved are not consecutive or if the backend in non ordered.
+
+    Example: 
+
+    GET <api URL>/node/3f8c/grayscale/specificblocks?blocks=x1,y1,z2,x2,y2,z2,x3,y3,z3
+	
+	This will fetch blocks at position (x1,y1,z1), (x2,y2,z2), and (x3,y3,z3).
+	The returned byte stream has a list of blocks with a leading block 
+	coordinate (3 x int32) plus int32 giving the # of bytes in this block, and  then the 
+	bytes for the value.  If blocks are unset within the span, they will not appear in the stream,
+	so the returned data will be equal to or less than spanX blocks worth of data.  
+
+	The returned data format has the following format where int32 is in little endian and the bytes 
+	of block data have been compressed in the desired output format, according to the specification 
+	in "compression" query string.
+
+        int32  Block 1 coordinate X (Note that this may not be starting block coordinate if it is unset.)
+        int32  Block 1 coordinate Y
+        int32  Block 1 coordinate Z
+        int32  # bytes for first block (N1)
+        byte0  Bytes of block data in compressed format.
+        byte1
+        ...
+        byteN1
+
+        int32  Block 2 coordinate X
+        int32  Block 2 coordinate Y
+        int32  Block 2 coordinate Z
+        int32  # bytes for second block (N2)
+        byte0  Bytes of block data in compressed format.
+        byte1
+        ...
+        byteN2
+
+        ...
+
+    If a block is not available, no data will be returned for it.
+
+    Arguments:
+
+	supervoxels   If "true", returns unmapped supervoxels, disregarding any kind of merges.
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of labelmap instance.
+
+    Query-string Options:
+
+    blocks		  x,y,z... block string
+    scale         A number from 0 up to MaxDownresLevel where each level has 1/2 resolution of
+	              previous level.  Level 0 (default) is the highest resolution.
+	compression   Allows retrieval of block data in "lz4", "gzip", "blocks" (native DVID
+				  label blocks), or "uncompressed" (uint64 labels). Default is "blocks".
+  
+
+GET  <api URL>/node/<UUID>/<data name>/isotropic/<dims>/<size>/<offset>[/<format>][?queryopts]
+
+    Retrieves either 2d images (PNG by default) or 3d binary data, depending on the dims parameter.  
+    The 3d binary data response has "Content-type" set to "application/octet-stream" and is an array of 
+    voxel values in ZYX order (X iterates most rapidly).
+
+    Example: 
+
+    GET <api URL>/node/3f8c/segmentation/isotropic/0_1/512_256/0_0_100/jpg:80
+
+    Returns an isotropic XY slice (0th and 1st dimensions) with width (x) of 512 voxels and
+    height (y) of 256 voxels with offset (0,0,100) in JPG format with quality 80.
+    Additional processing is applied based on voxel resolutions to make sure the retrieved image 
+    has isotropic pixels.  For example, if an XZ image is requested and the image volume has 
+    X resolution 3 nm and Z resolution 40 nm, the returned image's height will be magnified 40/3
+    relative to the raw data.
+    The example offset assumes the "grayscale" data in version node "3f8c" is 3d.
+    The "Content-type" of the HTTP response should agree with the requested format.
+    For example, returned PNGs will have "Content-type" of "image/png", and returned
+    nD data will be "application/octet-stream".
+
+    Arguments:
+
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of labelmap instance.
+    dims          The axes of data extraction in form "i_j_k,..."  Example: "0_2" can be XZ.
+                    Slice strings ("xy", "xz", or "yz") are also accepted.
+    size          Size in voxels along each dimension specified in <dims>.
+    offset        Gives coordinate of first voxel using dimensionality of data.
+    format        Valid formats depend on the dimensionality of the request and formats
+                    available in server implementation.
+                  2D: "png", "jpg" (default: "png")
+                    jpg allows lossy quality setting, e.g., "jpg:80"
+                  nD: uses default "octet-stream".
+
+    Query-string Options:
+
+    roi       	  Name of roi data instance used to mask the requested data.
+    scale         A number from 0 up to MaxDownresLevel where each level beyond 0 has 1/2 resolution
+	                of previous level.  Level 0 is the highest resolution.
+    compression   Allows retrieval or submission of 3d data in "lz4" and "gzip"
+                    compressed format.  The 2d data will ignore this and use
+                    the image-based codec.
+    throttle      Only works for 3d data requests.  If "true", makes sure only N compute-intense operation 
+    				(all API calls that can be throttled) are handled.  If the server can't initiate the API 
+    				call right away, a 503 (Service Unavailable) status code is returned.
+
+
+GET  <api URL>/node/<UUID>/<data name>/raw/<dims>/<size>/<offset>[/<format>][?queryopts]
+
+    Retrieves either 2d images (PNG by default) or 3d binary data, depending on the dims parameter.  
+	The 3d binary data response has "Content-type" set to "application/octet-stream" and is a packed
+	array of voxel values (little-endian uint64 per voxel) in ZYX order (X iterates most rapidly).
+
+    Example: 
+
+    GET <api URL>/node/3f8c/segmentation/raw/0_1/512_256/0_0_100/jpg:80
+
+    Returns a raw XY slice (0th and 1st dimensions) with width (x) of 512 voxels and
+    height (y) of 256 voxels with offset (0,0,100) in JPG format with quality 80.
+    By "raw", we mean that no additional processing is applied based on voxel
+    resolutions to make sure the retrieved image has isotropic pixels.
+    The example offset assumes the "grayscale" data in version node "3f8c" is 3d.
+    The "Content-type" of the HTTP response should agree with the requested format.
+    For example, returned PNGs will have "Content-type" of "image/png", and returned
+    nD data will be "application/octet-stream". 
+
+    Arguments:
+
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of labelmap instance.
+    dims          The axes of data extraction in form "i_j_k,..."  
+                    Slice strings ("xy", "xz", or "yz") are also accepted.
+                    Example: "0_2" is XZ, and "0_1_2" is a 3d subvolume.
+    size          Size in voxels along each dimension specified in <dims>.
+    offset        Gives coordinate of first voxel using dimensionality of data.
+    format        Valid formats depend on the dimensionality of the request and formats
+                    available in server implementation.
+                    2D: "png", "jpg" (default: "png")
+                        jpg allows lossy quality setting, e.g., "jpg:80"
+                    nD: uses default "octet-stream".
+
+    Query-string Options:
+
+	supervoxels   If "true", returns unmapped supervoxels, disregarding any kind of merges.
+    roi           Name of roi data instance used to mask the requested data.
+    scale         A number from 0 up to MaxDownresLevel where each level beyond 0 has 1/2 resolution
+	                of previous level.  Level 0 is the highest resolution.
+    compression   Allows retrieval or submission of 3d data in "lz4","gzip", "google"
+                    (neuroglancer compression format), "googlegzip" (google + gzip)
+                    compressed format.  The 2d data will ignore this and use
+                    the image-based codec.
+    throttle      Only works for 3d data requests.  If "true", makes sure only N compute-intense operation 
+    				(all API calls that can be throttled) are handled.  If the server can't initiate the API 
+    				call right away, a 503 (Service Unavailable) status code is returned.
+
+GET  <api URL>/node/<UUID>/<data name>/pseudocolor/<dims>/<size>/<offset>[?queryopts]
+
+    Retrieves label data as pseudocolored 2D PNG color images where each label hashed to a different RGB.
+
+    Example: 
+
+    GET <api URL>/node/3f8c/segmentation/pseudocolor/0_1/512_256/0_0_100
+
+    Returns an XY slice (0th and 1st dimensions) with width (x) of 512 voxels and
+    height (y) of 256 voxels with offset (0,0,100) in PNG format.
+
+    Arguments:
+
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of labelmap instance.
+    dims          The axes of data extraction.  Example: "0_2" can be XZ.
+                    Slice strings ("xy", "xz", or "yz") are also accepted.
+    size          Size in voxels along each dimension specified in <dims>.
+    offset        Gives coordinate of first voxel using dimensionality of data.
+
+    Query-string Options:
+
+    roi       	  Name of roi data instance used to mask the requested data.
+    compression   Allows retrieval or submission of 3d data in "lz4" and "gzip"
+                    compressed format.
+    throttle      If "true", makes sure only N compute-intense operation (all API calls that can be throttled) 
+                    are handled.  If the server can't initiate the API call right away, a 503 (Service Unavailable) 
+                    status code is returned.
+
+GET <api URL>/node/<UUID>/<data name>/label/<coord>[?queryopts]
+
+	Returns JSON for the label at the given coordinate:
+	{ "Label": 23 }
+	
+    Arguments:
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of labelmap instance.
+    coord     	  Coordinate of voxel with underscore as separator, e.g., 10_20_30
+
+    Query-string Options:
+
+	supervoxels   If "true", returns unmapped supervoxel label, disregarding any kind of merges.
+    scale         A number from 0 up to MaxDownresLevel where each level beyond 0 has 1/2 resolution
+	                of previous level.  Level 0 is the highest resolution.
+
+GET <api URL>/node/<UUID>/<data name>/labels[?queryopts]
+
+	Returns JSON for the labels at a list of coordinates.  Expects JSON in GET body:
+
+	[ [x0, y0, z0], [x1, y1, z1], ...]
+
+	Returns for each POSTed coordinate the corresponding label:
+
+	[ 23, 911, ...]
+	
+    Arguments:
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of label data.
+
+    Query-string Options:
+
+	supervoxels   If "true", returns unmapped supervoxel label, disregarding any kind of merges.
+    scale         A number from 0 up to MaxDownresLevel where each level beyond 0 has 1/2 resolution
+	                of previous level.  Level 0 is the highest resolution.
+    hash          MD5 hash of request body content in hexadecimal string format.
+
+GET <api URL>/node/<UUID>/<data name>/mapping[?queryopts]
+
+	Returns JSON for mapped uint64 identifiers (labels). The mapping holds not only the
+	unique IDs of supervoxels but also newly created IDs for renumbered & cleaved bodies
+	that will never overlap with supervoxel IDs. 
+	
+	Expects JSON in GET body:
+
+	[ label1, label2, label3, ...]
+
+	Returns for each POSTed label the corresponding mapped label:
+
+	[ 23, 0, 911, ...]
+
+	The mapped label can be 0 in the following circumstances:
+	* The label was a supervoxel ID that was split into two different unique IDs.
+	* The label is used for a newly generated ID that will be a new renumbered label.
+	* The label is used for a newly generated ID that will represent a cleaved body ID.
+	
+    Arguments:
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of label data.
+
+    Query-string Options:
+
+	nolookup      if "true", dvid won't verify that a supervoxel actually exists by looking up
+	                the label indices.  Only use this if supervoxels were known to exist at some time.
+    hash          MD5 hash of request body content in hexadecimal string format.
+
+GET <api URL>/node/<UUID>/<data name>/supervoxel-splits
+
+	Returns JSON for all supervoxel splits that have occurred up to this version of the
+	labelmap instance.  The returned JSON is of format:
+
+		[
+			"abc123",
+			[[<mutid>, <old>, <remain>, <split>],
+			[<mutid>, <old>, <remain>, <split>],
+			[<mutid>, <old>, <remain>, <split>]],
+			"bcd234",
+			[[<mutid>, <old>, <remain>, <split>],
+			[<mutid>, <old>, <remain>, <split>],
+			[<mutid>, <old>, <remain>, <split>]]
+		]
+	
+	The UUID examples above, "abc123" and "bcd234", would be full UUID strings and are in order
+	of proximity to the given UUID.  So the first UUID would be the version of interest, then
+	its parent, and so on.
+		  
+    Arguments:
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of label data.
+
+
+GET <api URL>/node/<UUID>/<data name>/blocks/<size>/<offset>[?queryopts]
+
+    Gets blocks corresponding to the extents specified by the size and offset.  The
+    subvolume request must be block aligned.  This is the most server-efficient way of
+    retrieving the labelmap data, where data read from the underlying storage engine is 
+	written directly to the HTTP connection possibly after recompression to match the given 
+	query-string compression option.  The default labelmap compression 
+	is gzip on compressed DVID label Block serialization ("blocks" option).
+
+    Example: 
+
+    GET <api URL>/node/3f8c/segmentation/blocks/64_64_64/0_0_0
+
+	If block size is 32x32x32, this call retrieves up to 8 blocks where the first potential
+	block is at 0, 0, 0.  The returned byte stream has a list of blocks with a leading block 
+	coordinate (3 x int32) plus int32 giving the # of bytes in this block, and  then the 
+	bytes for the value.  If blocks are unset within the span, they will not appear in the stream,
+	so the returned data will be equal to or less than spanX blocks worth of data.  
+
+    The returned data format has the following format where int32 is in little endian and the 
+	bytes of block data have been compressed in the desired output format.
+
+        int32  Block 1 coordinate X (Note that this may not be starting block coordinate if it is unset.)
+        int32  Block 1 coordinate Y
+        int32  Block 1 coordinate Z
+        int32  # bytes for first block (N1)
+        byte0  Block N1 serialization using chosen compression format (see "compression" option below)
+        byte1
+        ...
+        byteN1
+
+        int32  Block 2 coordinate X
+        int32  Block 2 coordinate Y
+        int32  Block 2 coordinate Z
+        int32  # bytes for second block (N2)
+        byte0  Block N2 serialization using chosen compression format (see "compression" option below)
+        byte1
+        ...
+        byteN2
+
+        ...
+
+	If a block is not available, no data will be returned for it.
+
+    Arguments:
+
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of data to add.
+    size          Size in voxels along each dimension specified in <dims>.
+    offset        Gives coordinate of first voxel using dimensionality of data.
+
+    Query-string Options:
+
+	supervoxels   If "true", returns unmapped supervoxels, disregarding any kind of merges.
+	scale         A number from 0 up to MaxDownresLevel where each level beyond 0 has 1/2 resolution
+	                of previous level.  Level 0 is the highest resolution.
+    compression   Allows retrieval of block data in "lz4" (default), "gzip", blocks" (native DVID
+	              label blocks) or "uncompressed" (uint64 labels).
+    throttle      If "true", makes sure only N compute-intense operation (all API calls that can be 
+	              throttled) are handled.  If the server can't initiate the API call right away, a 503 
+                  (Service Unavailable) status code is returned.
+
+GET <api URL>/node/<UUID>/<data name>/maxlabel
+
+	GET returns the maximum label for the version of data in JSON form:
+
+		{ "maxlabel": <label #> }
+
+GET <api URL>/node/<UUID>/<data name>/nextlabel
+
+	GET returns what would be a new label for the version of data in JSON form assuming the version
+	has not been committed:
+
+		{ "nextlabel": <label #> }
+	
+
+-------------------------------------------------------------------------------------------------------
+--- The following endpoints require the labelmap data instance to have IndexedLabels set to true. ---
+-------------------------------------------------------------------------------------------------------
+
+GET <api URL>/node/<UUID>/<data name>/lastmod/<label>
+
+	Returns last modification metadata for a label in JSON:
+
+	{ "mutation id": 2314, "last mod user": "johndoe", "last mod time": "2000-02-01 12:13:14 +0000 UTC", "last mod app": "Neu3" }
+	
+	Time is returned in RFC3339 string format. Returns a status code 404 (Not Found)
+    if label does not exist.
+	
+    Arguments:
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of labelmap instance.
+    label     	  A 64-bit integer label id
+
+GET <api URL>/node/<UUID>/<data name>/supervoxels/<label>
+
+	Returns JSON for the supervoxels that have been agglomerated into the given label:
+
+	[ 23, 911, ...]
+
+	Returns a status code 404 (Not Found) if label does not exist.
+	
+    Arguments:
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of labelmap instance.
+    label     	  A 64-bit integer label id
+
+GET <api URL>/node/<UUID>/<data name>/size/<label>[?supervoxels=true]
+
+	Returns the size in voxels for the given label (or supervoxel) in JSON:
+
+	{ "voxels": 2314 }
+	
+	Returns a status code 404 (Not Found) if label does not exist.
+	
+    Arguments:
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of labelmap instance.
+    label     	  A 64-bit integer label id
+
+    Query-string Options:
+
+	supervoxels   If "true", interprets the given label as a supervoxel id, not a possibly merged label.
+
+GET <api URL>/node/<UUID>/<data name>/sizes[?supervoxels=true]
+
+	Returns the sizes in voxels for a list of labels (or supervoxels) in JSON.  Expects JSON
+	for the list of labels (or supervoxels) in the body of the request:
+
+	[ 1, 2, 3, ... ]
+
+	Returns JSON of the sizes for each of the above labels:
+
+	[ 19381, 308, 586, ... ]
+	
+	Returns a size of 0 if label does not exist.
+	
+    Arguments:
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of labelmap instance.
+
+    Query-string Options:
+
+	supervoxels   If "true", interprets the given labels as a supervoxel ids.
+    hash          MD5 hash of request body content in hexadecimal string format.
+
+GET <api URL>/node/<UUID>/<data name>/supervoxel-sizes/<label>
+
+	Returns the supervoxels and their sizes for the given label in JSON.
+	Although the position in the lists will match supervoxel label and size,
+	the supervoxels may not be ordered:
+	{
+		"supervoxels": [1,2,4,3,...],
+		"sizes": [100,200,400,300,...]
+	}
+
+	Returns a status code 404 (Not Found) if label does not exist.
+	
+    Arguments:
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of labelmap instance.
+    label     	  A 64-bit integer label id
+
+
+GET  <api URL>/node/<UUID>/<data name>/sparsevol-size/<label>[?supervoxels=true]
+
+	Returns JSON giving the number of voxels, number of native blocks and the coarse bounding box in DVID
+	coordinates (voxel space):
+
+	{ "voxels": 231387, numblocks": 1081, "minvoxel": [0, 11, 23], "maxvoxel": [1723, 1279, 4855]}
+
+	Returns a status code 404 (Not Found) if label does not exist.
+
+	Note that the minvoxel and maxvoxel coordinates are voxel coordinates that are
+	accurate to the block, not the voxel.
+
+    Query-string Options:
+
+	supervoxels   If "true", interprets the given label as a supervoxel id, not a possibly merged label.
+
+GET  <api URL>/node/<UUID>/<data name>/sparsevol/<label>?<options>
+
+	Returns a sparse volume with voxels of the given label in encoded RLE format.  The returned
+	data can be optionally compressed using the "compression" option below.
+
+	Returns a status code 404 (Not Found) if label does not exist.
+	
+	The encoding has the following possible format where integers are little endian and the order
+	of data is exactly as specified below:
+
+	Legacy RLEs ("rles") :
+
+	    byte     Payload descriptor:
+	               Bit 0 (LSB) - 8-bit grayscale
+	               Bit 1 - 16-bit grayscale
+	               Bit 2 - 16-bit normal
+	               If set to all 0, there is no payload and it's a binary sparse volume.
+	    uint8    Number of dimensions
+	    uint8    Dimension of run (typically 0 = X)
+	    byte     Reserved (to be used later)
+	    uint32    # Voxels [TODO.  0 for now]
+	    uint32    # Spans
+	    Repeating unit of:
+	        int32   Coordinate of run start (dimension 0)
+	        int32   Coordinate of run start (dimension 1)
+	        int32   Coordinate of run start (dimension 2)
+	        int32   Length of run
+	        bytes   Optional payload dependent on first byte descriptor
+			  ...
+	
+	Streaming RLEs ("srles"):
+
+	    Repeating unit of:
+	        int32   Coordinate of run start (dimension 0)
+	        int32   Coordinate of run start (dimension 1)
+	        int32   Coordinate of run start (dimension 2)
+	        int32   Length of run
+
+	Streaming Binary Blocks ("blocks"):
+
+      3 * uint32      values of gx, gy, and gz -- the # of sub-blocks along each dimension in a Block.
+      uint64          foreground label
+
+      Stream of blocks.  Each block has the following data:
+
+		3 * int32       offset of first voxel of Block in DVID space (x, y, z)
+		byte            content flag:
+						0 = background ONLY  (no more data for this block)
+						1 = foreground ONLY  (no more data for this block)
+						2 = both background and foreground so stream of sub-blocks required.
+
+		If content is both background and foreground, stream of gx * gy * gz sub-blocks with the following data:
+
+		byte            content flag:
+						0 = background ONLY  (no more data for this sub-block)
+						1 = foreground ONLY  (no more data for this sub-block)
+						2 = both background and foreground so mask data required.
+		mask            64 byte bitmask where each voxel is 0 (background) or 1 (foreground)
+
+    GET Query-string Options:
+
+	format  One of the following:
+	          "rles" (default) - legacy RLEs with header including # spans.Data
+			  "srles" - streaming RLEs with each RLE composed of 4 int32 (16 bytes) for x, y, z, run 
+			  "blocks" - binary Block stream
+
+    minx    Spans must be >= this minimum x voxel coordinate at given scale
+    maxx    Spans must be <= this maximum x voxel coordinate at given scale.
+    miny    Spans must be >= this minimum y voxel coordinate at given scale.
+    maxy    Spans must be <= this maximum y voxel coordinate at given scale.
+    minz    Spans must be >= this minimum z voxel coordinate at given scale.
+    maxz    Spans must be <= this maximum z voxel coordinate at given scale.
+    exact   "false" if RLEs can extend a bit outside voxel bounds within border blocks.
+             This will give slightly faster responses. 
+
+    compression  "lz4" and "gzip" compressed format; only applies to "rles" format for now.
+	scale        A number from 0 (default highest res) to MaxDownresLevel where each level 
+				   beyond 0 has 1/2 resolution of previous level.
+	supervoxels   If "true", interprets the given label as a supervoxel id.
+
+
+HEAD <api URL>/node/<UUID>/<data name>/sparsevol/<label>[?supervoxels=true]
+
+	Returns:
+		200 (OK) if a sparse volume of the given label exists within any optional bounds.
+		204 (No Content) if there is no sparse volume for the given label within any optional bounds.
+
+	Note that for speed, the optional bounds are always expanded to the block-aligned containing
+	subvolume, i.e., it's as if exact=false for the corresponding GET.
+
+    GET Query-string Options:
+
+    minx    Spans must be equal to or larger than this minimum x voxel coordinate.
+    maxx    Spans must be equal to or smaller than this maximum x voxel coordinate.
+    miny    Spans must be equal to or larger than this minimum y voxel coordinate.
+    maxy    Spans must be equal to or smaller than this maximum y voxel coordinate.
+    minz    Spans must be equal to or larger than this minimum z voxel coordinate.
+    maxz    Spans must be equal to or smaller than this maximum z voxel coordinate.
+
+    Query-string Options:
+
+	supervoxels   If "true", interprets the given label as a supervoxel id, not a possibly merged label.
+
+GET <api URL>/node/<UUID>/<data name>/sparsevol-by-point/<coord>[?supervoxels=true]
+
+	Returns a sparse volume with voxels that pass through a given voxel.
+	The encoding is described in the "sparsevol" request above.
+	
+    Arguments:
+
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of mapping data.
+    coord     	  Coordinate of voxel with underscore as separator, e.g., 10_20_30
+
+    Query-string Options:
+
+	supervoxels   If "true", returns the sparsevol of the supervoxel designated by the point.
+
+GET <api URL>/node/<UUID>/<data name>/sparsevol-coarse/<label>?<options>
+
+	Returns a sparse volume with blocks of the given label in encoded RLE format.
+	The encoding has the following format where integers are little endian and the order
+	of data is exactly as specified below:
+
+	    byte     Set to 0
+	    uint8    Number of dimensions
+	    uint8    Dimension of run (typically 0 = X)
+	    byte     Reserved (to be used later)
+	    uint32    # Blocks [TODO.  0 for now]
+	    uint32    # Spans
+	    Repeating unit of:
+	        int32   Block coordinate of run start (dimension 0)
+	        int32   Block coordinate of run start (dimension 1)
+	        int32   Block coordinate of run start (dimension 2)
+			  ...
+	        int32   Length of run
+
+	Note that the above format is the RLE encoding of sparsevol, where voxel coordinates
+	have been replaced by block coordinates.
+
+	Returns a status code 404 (Not Found) if label does not exist.
+	
+	GET Query-string Options:
+
+	supervoxels   If "true", interprets the given label as a supervoxel id.
+
+	minx    Spans must be equal to or larger than this minimum x voxel coordinate.
+    maxx    Spans must be equal to or smaller than this maximum x voxel coordinate.
+    miny    Spans must be equal to or larger than this minimum y voxel coordinate.
+    maxy    Spans must be equal to or smaller than this maximum y voxel coordinate.
+    minz    Spans must be equal to or larger than this minimum z voxel coordinate.
+    maxz    Spans must be equal to or smaller than this maximum z voxel coordinate.
+
+
+GET <api URL>/node/<UUID>/<data name>/sparsevols-coarse/<start label>/<end label>
+
+	Note: this request does not reflect ongoing merges/splits but is meant to be used
+	for various batch operations on a static node.
+
+	Returns a stream of sparse volumes with blocks of the given label in encoded RLE format:
+
+		uint64   label
+		<coarse sparse vol as given below>
+
+		uint64   label
+		<coarse sparse vol as given below>
+
+		...
+
+	The coarse sparse vol has the following format where integers are little endian and the order
+	of data is exactly as specified below:
+
+		int32    # Spans
+		Repeating unit of:
+			int32   Block coordinate of run start (dimension 0)
+			int32   Block coordinate of run start (dimension 1)
+			int32   Block coordinate of run start (dimension 2)
+			int32   Length of run
+
+
+GET <api URL>/node/<UUID>/<data name>/proximity/<label 1 (target)>,<label 2a>,<label 2b>,...
+
+	Determines proximity of a number of labels with a target label returning the 
+	following JSON giving blocks in which they intersect and the min euclidean 
+	voxel distance between the labels within that block:
+		[
+			{ 
+				"Block": [<x1>, <y1>, <z1>],
+				"Label": <label 2a>,
+				"Distance": <min euclidean voxel distance in block 1 to label 2a>
+			}, 
+			{ 
+				"Block": [<x1>, <y1>, <z1>],
+				"Label": <label 2b>
+				"Distance": <min euclidean voxel distance in block 1 to label 2b>
+			},
+			...
+		]
+	If only two labels are specified, the "Label" property is omitted.
+
+	Note that this is an approximation in that we assume two labels aren't perfectly
+	separated across block boundaries. This could be the case for supervoxels that
+	are artificially split along block boundaries but won't be true for agglomerated
+	labels.
+	
+GET  <api URL>/node/<UUID>/<data name>/index/<label>?mutid=<uint64>
+
+	Allows direct retrieval of an index (blocks per supervoxel and their voxel count) 
+	for a label.  Typically, these indices are computed on-the-fly during ingestion of
+	of blocks of label voxels.  If there are cluster systems capable of computing label
+	blocks, indices, and affinities directly, though, it's more efficient to simply POST
+	them into dvid.
+
+	The returned (GET) protobuf serialization of a LabelIndex message is defined by:
+
+	message SVCount {
+		map<uint64, uint32> counts = 1;
+	}
+
+	message LabelIndex {
+		map<uint64, SVCount> blocks = 1;  // key is encoded block coord ZYX (packed little-endian 21-bit numbers where MSB is sign flag)
+		uint64 label = 2;
+		uint64 last_mut_id = 3;
+		string last_mod_time = 4;  // string is time in RFC 3339 format
+		string last_mod_user = 5;
+		string last_mod_app = 6;
+	}
+
+	Query-string options:
+
+		metadata-only: if "true" (default "false"), returns JSON object of num_voxels, last_mutid, last_mod_time, last_mod_user.
+		mutid: (Read only) Returns the label index prior to completing the given mutation id in the current branch. If
+		   no cached label index is found prior to the given mutation id in the branch of the specified UUID, 
+		   a 404 not found is returned.
+
+	
+GET <api URL>/node/<UUID>/<data name>/existing-labels
+
+	Streams JSON list of all existing labels in the most computationally efficient manner,
+	particularly when backed by a Badger key-value store or other backend that has fast
+	key scans.
+
+	Note that because the data is streamed over HTTP, an error code cannot be sent once data is 
+	in flight.
+
+GET <api URL>/node/<UUID>/<data name>/listlabels[?queryopts]
+
+	Streams labels and optionally their voxel counts in numerical order up to a maximum
+	of 10 million labels.  The GET returns a stream of little-endian uint64.  If label sizes are
+	requested, the stream is <label id i> <voxels in label i> <label id i+1> <voxels in label i+1> ...
+	If label sizes aren't requested, the stream is simply <label id i> <label id i+1> ...
+
+	Note that because the data is streamed over HTTP, an error code cannot be sent once data is 
+	in flight, so any error is marked by four consecutive uint64 with value 0.
+
+	The query strings allow you to page through vast amounts of labels by changing the start. 
+	For example:
+	   GET /api/node/37af8/segmentation/listlabels
+	      which is equivalent to
+	   GET /api/node/37af8/segmentation/listlabels?start=0    --> say it returns up to label 10,281,384 due to some gaps in labeling.
+	      and then you can call
+	   GET /api/node/37af8/segmentation/listlabels?start=10281385   --> to return next batch, start with last received label + 1
+	
+	Note that the start is a label identifier and not a position or index.  Since labels are
+	stored consecutively, you can omit the start query string (default is start=0) to guarantee 
+	you will get the smallest label identifier, which should be non-zero since 0 is used only for background.
+	
+	Query-string options:
+
+		start: starting label id (use 0 to start at very beginning since labels are stored consecutively)
+		number: number of labels to return (if not specified, returns maximum of 10,000,000 labels)
+		sizes: if "true", returns the number of voxels for each label.
+
+GET <api URL>/node/<UUID>/<data name>/indices
+
+	Note: For more optimized bulk index retrieval, see /indices-compressed.
+	Allows bulk GET of indices (blocks per supervoxel and their voxel count) by
+	including in the GET body a JSON array of requested labels (max 50,000 labels):
+
+		[ 1028193, 883177046, ... ]
+
+	The GET returns a protobuf serialization of a LabelIndices message defined by:
+	
+	message LabelIndices {
+		repeated LabelIndex indices = 1;
+	}
+
+	where LabelIndex is defined by the protobuf above in the /index documentation.
+
+GET <api URL>/node/<UUID>/<data name>/indices-compressed
+
+	The fastest and most efficient way for bulk index retrieval.  Streams lz4 
+	compressed LabelIndex protobuf messages with minimal processing server-side.  
+	This allows lz4 uncompression to be done in parallel on clients as well as
+	immediate processing of each label index as it is received.
+	Up to 50,000 labels may be requested at once by sending a JSON array of 
+	requested labels in GET body:
+
+		[ 1028193, 883177046, ... ]
+
+	The GET returns a stream of data with the following format:
+
+	first label index compressed size in bytes (uint64 little endian)
+	first label id (uint64 little endian)
+	first label index protobuf (see definition in /index doc), lz4 compressed
+	second label index compressed size in bytes (uint64 little endian)
+	second label id (uint64 little endian)
+	second label index protobuf, lz4 compressed
+	...
+
+	Although the label id is included in the protobuf, the stream includes the label
+	of the record in case there is corruption of the record or other issues.  So this
+	call allows verifying the records are properly stored.  
+
+	Missing labels will have 0 size and no bytes for the protobuf data.
+
+	If an error occurs, zeros will be transmitted for a label index size and a label id.
+	
+GET <api URL>/node/<UUID>/<data name>/mutations[?queryopts]
+
+	Returns JSON list of the successfully completed mutations for the given version 
+	for this data instance.  Each mutation record format is equivalent to the JSON 
+	provided to the Kafka mutation log.  For example, a merge mutation would be:
+
+	{
+		"Action": "merge",
+		"Target": <label ID>,
+		"Labels": [<merged label 1>, <merged label 2>, ...],
+		"UUID": "28841c8277e044a7b187dda03e18da13",
+		"MutationID": <uint64>,
+		"Timestamp": <string>,
+		"User": <user id string if supplied during mutation>,
+		"App": <app id string if supplied during mutation>
+	}
+
+	Query-string options:
+
+		userid:  Limit returned mutations to the given User ID.  Note that
+				 this should be distinguished from the "u" query string which
+				 is the requester's User ID (not necessarily the same as the
+				 User ID whose mutations are being requested).
+
+
+GET <api URL>/node/<UUID>/<data name>/mutations-range/<beg>/<end>
+
+	Returns JSON list of the successfully completed mutations across the given
+	range of UUIDs.  Each mutation record format is equivalent to the JSON
+	provided to the Kafka mutation log as in the /mutations endpoint. 
+
+
+GET <api URL>/node/<UUID>/<data name>/history/<label>/<from UUID>/<to UUID>
+
+	Returns JSON for mutations involving labels in "from UUID" version that correspond to the
+	supervoxels in the "to UUID" target label.
+	
+	Arguments:
+	UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+	data name     Name of labelmap instance.
+	label     	  The label ID as exists in the later version specified by <to UUID>.
+	from UUID     The UUID of the earlier version in time range.
+	to UUID       The UUID of the later version in time range.
+	
+	
+GET <api URL>/node/<UUID>/<data name>/mappings[?queryopts]
+
+	Streams space-delimited mappings for the given UUID, one mapping per line:
+
+		supervoxel0 mappedTo0
+		supervoxel1 mappedTo1
+		supervoxel2 mappedTo2
+		...
+		supervoxelN mappedToN
+	
+	Note that only non-identity mappings are presented unless the mapping is 
+	associated with some kind of mutation.  The mapping contains not only the 
+	unique IDs of supervoxels but also newly created IDs for renumbered & 
+	cleaved bodies that will never overlap with supervoxel IDs. 
+	
+	The mapped label can be 0 in the following circumstances:
+	* The label was a supervoxel ID that was split into two different unique IDs.
+	* The label is used for a newly generated ID that will be a new renumbered label.
+	* The label is used for a newly generated ID that will represent a cleaved body ID.
+
+	Query-string Options:
+
+		format: If format=binary, the data is returned as little-endian binary uint64 pairs,
+				in the same order as shown in the CSV format above.
+
+### annotation Datatype HTTP API
+
+Example JSON Format of point annotation elements with ... marking omitted elements:
+
+[
+	{
+		"Pos":[33,30,31],
+		"Kind":"PostSyn",
+		"Rels":[ 
+			{"Rel":"PostSynTo", "To":[15,27,35]} 
+		],
+		"Tags":["Synapse1"],
+		"Prop": {
+			"SomeVar": "SomeValue",
+			"Another Var": "A More Complex Value"
+		}
+	},
+	{
+		"Pos":[15,27,35],
+		"Kind":"PreSyn",
+		"Rels":[
+			{"Rel":"PreSynTo", "To":[20,30,40]},
+			{"Rel":"PreSynTo", "To":[14,25,37]},
+			{"Rel":"PreSynTo", "To":[33,30,31]}
+		],
+		"Tags":["Synapse1"]
+	},
+	{
+		"Pos":[20,30,40],
+		"Kind":"PostSyn",
+		"Rels":[
+			{"Rel":"PostSynTo","To":[15,27,35]}
+		],
+		"Tags":["Synapse1"],
+		"Prop": {
+			"SomeVar": "SomeValue",
+			"Another Var 2": "A More Complex Value 2"
+		}
+	},
+	...
+]
+
+The "Kind" property can be one of "Unknown", "PostSyn", "PreSyn", "Gap", or "Note".
+
+The "Rel" property can be one of "UnknownRelationship", "PostSynTo", "PreSynTo", "ConvergentTo", or "GroupedWith".
+
+The "Tags" property will be indexed and so can be costly if used for very large numbers of synapse elements.
+
+The "Prop" property is an arbitrary object with string values.  The "Prop" object's key are not indexed.
+
+
+GET  <api URL>/node/<UUID>/<data name>/help
+
+	Returns data-specific help message.
+
+
+GET  <api URL>/node/<UUID>/<data name>/info
+
+    Retrieves DVID-specific data properties for these voxels.
+
+    Example: 
+
+    GET <api URL>/node/3f8c/synapses/info
+
+    Returns JSON with configuration settings.
+
+    Arguments:
+
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of annotation data.
+
+
+GET <api URL>/node/<UUID>/<data name>/tags
+
+	GET retrieves JSON of tags for this instance.
+
+	{ "tag1": "anything you want", "tag2": "something else" }
+		   
+		   
+Note: For the following URL endpoints that return and accept POSTed JSON values, see the JSON format
+at beginning of this documentation.
+
+GET <api URL>/node/<UUID>/<data name>/label/<label>[?<options>]
+
+	Returns all point annotations within the given label as an array of elements.
+	This endpoint is only available if the annotation data instance is synced with
+	voxel label data instances (labelblk, labelarray, labelmap).
+	
+	GET Query-string Option:
+
+	relationships   Set to true to return all relationships for each annotation.
+
+	Example:
+
+	GET http://foo.com/api/node/83af/myannotations/label/23?relationships=true
+
+
+GET <api URL>/node/<UUID>/<data name>/tag/<tag>[?<options>]
+
+	Returns all point annotations with the given tag as an array of elements.
+	By default, the Relationships of an annotation to other annotations is not
+	returned.  If you want the Relationships, use the query string below.
+
+	GET Query-string Option:
+
+	relationships   Set to true to return all relationships for each annotation.
+
+	Example:
+
+	GET http://foo.com/api/node/83af/myannotations/tag/goodstuff?relationships=true
+	
+
+GET <api URL>/node/<UUID>/<data name>/roi/<ROI specification>
+
+	Returns all point annotations within the ROI.  The ROI specification must be specified
+	using a string of format "roiname,uuid".  If just "roiname" is specified without
+	a full UUID string, the current UUID of the request will be used.  Currently, this 
+	request will only work for ROIs that have same block size as the annotation data instance.
+
+	The returned point annotations will be an array of elements.
+
+GET <api URL>/node/<UUID>/<data name>/elements/<size>/<offset>
+
+	Returns all point annotations within subvolume of given size with upper left corner
+	at given offset.  The size and offset should be voxels separated by underscore, e.g.,
+	"400_300_200" can describe a 400 x 300 x 200 volume or an offset of (400,300,200).
+
+	The returned point annotations will be an array of elements with relationships.
+
+GET <api URL>/node/<UUID>/<data name>/scan[?<options>]
+
+	Scans the annotations stored in blocks and returns simple stats on usage
+	in JSON format.
+
+	GET Query-string Options:
+
+	byCoord    If "true" (not set by default), the scan bounds will be by min/max 
+			    block coord instead of internal constants.
+	keysOnly   If "true" (not set by default), scans using keys only range query
+	            and will not check if value is empty.
+
+
+GET <api URL>/node/<UUID>/<data name>/all-elements
+
+	Returns all point annotations in the entire data instance, which could exceed data
+	response sizes (set by server) if too many elements are present.  This should be
+	equivalent to the /blocks endpoint but without the need to determine extents.
+
+	The returned stream of data is the same as /blocks endpoint below.
+
+
+GET <api URL>/node/<UUID>/<data name>/blocks/<size>/<offset>
+
+	Returns all point annotations within all blocks intersecting the subvolume of given size 
+	with upper left corner at given offset.  The size and offset should be voxels separated by 
+	underscore, e.g., "400_300_200" can describe a 400 x 300 x 200 volume or an offset of (400,300,200).
+
+	Unlike the /elements endpoint, the /blocks endpoint is the fastest way to retrieve
+	all point annotations within a bounding box.  It does not screen points based on the specified 
+	subvolume but simply streams all elements (including relationships) in the intersecting blocks.
+	The fastest way to get all point annotations in entire volume (no bounding box) is via /all-elements.
+
+	The returned stream of data is an object with block coordinate as keys and an array of point
+	annotation elements within that block, meeting the JSON described below.
+
+	If the data instance has Tag "ScanAllForBlocks" is set to "true", it's assumed there are
+	relatively few annotations across blocks so a single range query is used rather than many
+	range queries to span the given X range of the bounding box.
+
+	Returned JSON:
+
+	{
+		"10,381,28": [ array of point annotation elements ],
+		"11,381,28": [ array of point annotation elements ],
+		...
+	}
+
+
+### roi Datatype HTTP API
+
+GET  <api URL>/node/<UUID>/<data name>/help
+
+	Returns data-specific help message.
+
+
+GET  <api URL>/node/<UUID>/<data name>/info
+
+    Retrieves data properties.
+
+    Example: 
+
+    GET <api URL>/node/3f8c/stuff/info
+
+    Returns JSON with configuration settings.
+
+    Arguments:
+
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of roi data.
+
+
+GET  <api URL>/node/<UUID>/<data name>/roi
+
+    Performs operations on an ROI depending on the HTTP verb.
+
+    Example: 
+
+    GET <api URL>/node/3f8c/medulla/roi
+
+    Returns the data associated with the "medulla" ROI at version 3f8c.
+    If an ROI is currently being created asynchronously, e.g., during an imageblk
+    foreground command, then a HTTP status code 206 (Partial Content) is returned
+    until the ROI is completely stored (HTTP status code 200).
+
+    The "Content-type" of the HTTP response (and usually the request) are
+    "application/json" for arbitrary binary data.  Returns a list of 4-tuples:
+
+  	"[[0, 0, 0, 1], [0, 2, 3, 5], [0, 2, 8, 9], [1, 2, 3, 4]]"
+
+	Each element is expressed as [z, y, x0, x1], which represents blocks with the block coordinates
+	(x0, y, z) to (x1, y, z).  Each block is a chunking of voxel space using the BlockSize for 
+	the ROI.
+
+    Arguments:
+
+    UUID          Hexadecimal string with enough characters to uniquely identify a version node.
+    data name     Name of ROI data to save/modify or get.
+
+GET <api URL>/node/<UUID>/<data name>/mask/0_1_2/<size>/<offset>
+
+	Returns a binary volume in ZYX order (increasing X is contiguous in array) same as format of
+	the nD voxels GET request.  The returned payload is marked as "octet-stream".
+
+	The request must have size and offset arguments (both must be given if included) similar
+	to the nD voxels GET request.  Currently, only the 3d GET is implemented, although in the
+	future this endpoint will parallel voxel GET request.
+
+	Example:
+
+	GET <api URL>/node/3f8c/myroi/mask/0_1_2/512_512_256/100_200_300
+
+	Returns a binary volume with non-zero elements for voxels within ROI.  The binary volume
+	has size 512 x 512 x 256 voxels and an offset of (100, 200, 300).
+
+
+POST <api URL>/node/<UUID>/<data name>/ptquery
+
+	Determines whether a list of 3d points (voxel coordinates) in JSON format sent by POST is within 
+	the ROI.  Returns a list of true/false answers for each point in the same sequence as the POSTed 
+	list.  The send format is:
+
+	[[x0, y0, z0], [x1, y1, z1], ...]
+
+    The "Content-type" of the HTTP response (and usually the request) are
+    "application/json" for arbitrary binary data.  Example:
+
+  	Sent: "[[0, 100, 910], [0, 121, 900]]"
+
+  	Returned: "[false, true]"
+
+
+GET <api URL>/node/<UUID>/<data name>/partition?batchsize=8
+
+	Returns JSON of subvolumes that are batchsize^3 blocks in volume and cover the ROI.
+
+    Query-string Options:
+
+    batchsize	Number of blocks along each axis to batch to make one subvolume (default = 8)
+    optimized   If "true" or "on", partitioning returns non-fixed sized subvolumes where the coverage
+                  is better in terms of subvolumes having more active blocks.


### PR DESCRIPTION
Extract mostly read-only API endpoints from important datatypes with introductory context orienting entities to the DVID system. @stuarteberg 