### PR TITLE
Make better error message for temporary label index error

### DIFF
--- a/cmd/dvid/main.go
+++ b/cmd/dvid/main.go
@@ -6,7 +6,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -236,7 +236,7 @@ func DoCommand(cmd dvid.Command) error {
 		request := datastore.Request{Command: cmd}
 		if *useStdin {
 			var err error
-			request.Input, err = ioutil.ReadAll(os.Stdin)
+			request.Input, err = io.ReadAll(os.Stdin)
 			if err != nil {
 				return fmt.Errorf("Error in reading from standard input: %v", err)
 			}

--- a/cmd/labelblock/main.go
+++ b/cmd/labelblock/main.go
@@ -4,7 +4,7 @@ import (
 	"compress/gzip"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/janelia-flyem/dvid/datatype/common/labels"
@@ -54,7 +54,7 @@ func main() {
 }
 
 func compress() {
-	b, err := ioutil.ReadAll(os.Stdin)
+	b, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error reading stdin: %v\n", err)
 		os.Exit(1)
@@ -95,7 +95,7 @@ func uncompress() {
 		os.Exit(1)
 	}
 
-	serialization, err := ioutil.ReadAll(fz)
+	serialization, err := io.ReadAll(fz)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to uncompress gzip input: %v\n", err)
 		os.Exit(1)

--- a/cmd/labelmap-utils/analyze-block/main.go
+++ b/cmd/labelmap-utils/analyze-block/main.go
@@ -6,7 +6,7 @@ import (
 	"encoding/binary"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -87,7 +87,7 @@ func main() {
 		fmt.Printf("bad HTTP blocks request response: %v\n", err)
 		os.Exit(1)
 	}
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
 		fmt.Printf("couldn't read block data: %v\n", err)
@@ -116,7 +116,7 @@ func main() {
 		fmt.Printf("can't uncompress gzip block: %v\n", err)
 		os.Exit(1)
 	}
-	uncompressed, err = ioutil.ReadAll(zr)
+	uncompressed, err = io.ReadAll(zr)
 	if err != nil {
 		fmt.Printf("can't uncompress gzip block: %v\n", err)
 		os.Exit(1)

--- a/cmd/labelmap-utils/analyze-index/main.go
+++ b/cmd/labelmap-utils/analyze-index/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -83,7 +83,7 @@ func main() {
 
 	url := fmt.Sprintf("http://%s/api/node/%s/%s/index/%d", server, uuid, name, label)
 	resp, err := http.Get(url)
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		fmt.Printf("couldn't read index data: %v\n", err)
 		os.Exit(1)

--- a/cmd/labeltest/main.go
+++ b/cmd/labeltest/main.go
@@ -6,7 +6,7 @@ import (
 	"encoding/binary"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -98,7 +98,7 @@ func main() {
 		if resp.StatusCode != http.StatusOK {
 			os.Exit(1)
 		}
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
 			fmt.Printf("error on trying to read sparsevol %d response: %v\n", label, err)

--- a/cmd/transfer/transfer.go
+++ b/cmd/transfer/transfer.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -39,7 +38,7 @@ func getLabelMetadata(dstURL string) *LabelMetadata {
 		fmt.Printf("Bad status on getting metadata (%s): %d\n", infoUrl, resp.StatusCode)
 		os.Exit(1)
 	}
-	metadata, err := ioutil.ReadAll(resp.Body)
+	metadata, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
 		fmt.Printf("Could not read metadata from labels (%s): %v\n", infoUrl, err.Error())
@@ -210,7 +209,7 @@ func sendStrip(name, srcURL string, vx, vy, vz, ox, oy, oz int) {
 		}
 		if resp.StatusCode != http.StatusOK {
 			var respnote []byte
-			data, _ := ioutil.ReadAll(resp.Body)
+			data, _ := io.ReadAll(resp.Body)
 			if len(data) < 2000 {
 				respnote = data
 			}

--- a/datatype/annotation/annotation.go
+++ b/datatype/annotation/annotation.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"sort"
@@ -2173,7 +2172,7 @@ type blockList map[string]Elements
 // StoreBlocks performs a synchronous store of synapses in JSON format, not
 // returning until the data blocks are complete.
 func (d *Data) StoreBlocks(ctx *datastore.VersionedCtx, r io.Reader, kafkaOff bool) (numBlocks int, err error) {
-	jsonBytes, err := ioutil.ReadAll(r)
+	jsonBytes, err := io.ReadAll(r)
 	if err != nil {
 		return 0, err
 	}
@@ -2240,7 +2239,7 @@ func (d *Data) StoreBlocks(ctx *datastore.VersionedCtx, r io.Reader, kafkaOff bo
 // StoreElements performs a synchronous store of synapses in JSON format, not
 // returning until the data and its denormalizations are complete.
 func (d *Data) StoreElements(ctx *datastore.VersionedCtx, r io.Reader, kafkaOff bool) error {
-	jsonBytes, err := ioutil.ReadAll(r)
+	jsonBytes, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/datatype/annotation/handlers.go
+++ b/datatype/annotation/handlers.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -444,7 +443,7 @@ func (d *Data) handlePostLabels(ctx *datastore.VersionedCtx, w http.ResponseWrit
 	if err != nil {
 		return err
 	}
-	jsonBytes, err := ioutil.ReadAll(r)
+	jsonBytes, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/datatype/common/labels/compressed_test.go
+++ b/datatype/common/labels/compressed_test.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -84,7 +84,7 @@ func readGzipFile(filename string) ([]byte, error) {
 	}
 	defer fz.Close()
 
-	data, err := ioutil.ReadAll(fz)
+	data, err := io.ReadAll(fz)
 	if err != nil {
 		return nil, err
 	}
@@ -443,7 +443,7 @@ func TestSolidBlockRLE(t *testing.T) {
 	if err := outOp.Finish(); err != nil {
 		t.Fatalf("error writing RLEs: %v\n", err)
 	}
-	output, err := ioutil.ReadAll(&buf)
+	output, err := io.ReadAll(&buf)
 	if err != nil {
 		t.Fatalf("error on reading WriteRLEs: %v\n", err)
 	}
@@ -727,7 +727,7 @@ func TestBlockSplitAndRLEs(t *testing.T) {
 	if err = outOp.Finish(); err != nil {
 		t.Fatalf("error writing RLEs: %v\n", err)
 	}
-	output, err := ioutil.ReadAll(&buf)
+	output, err := io.ReadAll(&buf)
 	if err != nil {
 		t.Fatalf("error on reading WriteRLEs: %v\n", err)
 	}
@@ -1085,7 +1085,7 @@ func BenchmarkDvidUnmarshalGzip(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		data, err := ioutil.ReadAll(zr)
+		data, err := io.ReadAll(zr)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/datatype/common/labels/index.go
+++ b/datatype/common/labels/index.go
@@ -423,6 +423,9 @@ func (idx *Index) Add(idx2 *Index, mutInfo dvid.MutInfo) error {
 			// that supervoxel can't be in idx.
 			for sv2, c2 := range svc2.Counts {
 				if _, found := svc.Counts[sv2]; found {
+					if idx.Label == 0 {
+						return fmt.Errorf("supervoxel %d already in temporary index", sv2)
+					}
 					return fmt.Errorf("supervoxel %d already in index for target label %d", sv2, idx.Label)
 				}
 				svc.Counts[sv2] = c2

--- a/datatype/googlevoxels/googlevoxels.go
+++ b/datatype/googlevoxels/googlevoxels.go
@@ -257,7 +257,7 @@ func (dtype *Type) NewDataService(uuid dvid.UUID, id dvid.InstanceID, name dvid.
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("Unexpected status code %d returned when getting volume metadata for %q", resp.StatusCode, volumeid)
 	}
-	metadata, err := ioutil.ReadAll(resp.Body)
+	metadata, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -368,7 +368,7 @@ func (dtype *Type) Do(cmd datastore.Request, reply *datastore.Response) error {
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("Unexpected status code %d returned when getting volumes for user", resp.StatusCode)
 		}
-		metadata, err := ioutil.ReadAll(resp.Body)
+		metadata, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -1002,7 +1002,7 @@ func (d *Data) serveTile(w http.ResponseWriter, r *http.Request, geom *GoogleSub
 	// If it's on edge, we need to pad the tile to the tile size.
 	if geom.edge {
 		// We need to read whole thing in to pad it.
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		timedLog.Infof("Got edge tile from Google, %d bytes\n", len(data))
 		if err != nil {
 			return err
@@ -1091,7 +1091,7 @@ func (d *Data) serveVolume(w http.ResponseWriter, r *http.Request, geom *GoogleS
 
 	switch compression {
 	case "lz4":
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		timedLog.Infof("Got raw subvolume from Google, %d bytes\n", len(data))
 		if err != nil {
 			return err

--- a/datatype/imageblk/imageblk.go
+++ b/datatype/imageblk/imageblk.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"image"
 	"image/jpeg"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"reflect"
@@ -2313,7 +2313,7 @@ func (d *Data) ServeHTTP(uuid dvid.UUID, ctx *datastore.VersionedCtx, w http.Res
 			server.BadRequest(w, r, "extents endpoint only supports POST HTTP verb")
 			return
 		}
-		jsonBytes, err := ioutil.ReadAll(r.Body)
+		jsonBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			server.BadRequest(w, r, err)
 			return
@@ -2328,7 +2328,7 @@ func (d *Data) ServeHTTP(uuid dvid.UUID, ctx *datastore.VersionedCtx, w http.Res
 			server.BadRequest(w, r, "resolution endpoint only supports POST HTTP verb")
 			return
 		}
-		jsonBytes, err := ioutil.ReadAll(r.Body)
+		jsonBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			server.BadRequest(w, r, err)
 			return
@@ -2630,7 +2630,7 @@ func (d *Data) ServeHTTP(uuid dvid.UUID, ctx *datastore.VersionedCtx, w http.Res
 					server.BadRequest(w, r, "Data %q uses an immutable GridStore so cannot received POSTs", d.DataName())
 					return
 				}
-				data, err := ioutil.ReadAll(r.Body)
+				data, err := io.ReadAll(r.Body)
 				if err != nil {
 					server.BadRequest(w, r, err)
 					return

--- a/datatype/imagetile/imagetile.go
+++ b/datatype/imagetile/imagetile.go
@@ -1,8 +1,8 @@
 /*
-	Package imagetile implements DVID support for imagetiles in XY, XZ, and YZ orientation.
-	All raw tiles are stored as PNG images that are by default gzipped.  This allows raw
-	tile gets to be already compressed at the cost of more expensive uncompression to
-	retrieve arbitrary image sizes.
+Package imagetile implements DVID support for imagetiles in XY, XZ, and YZ orientation.
+All raw tiles are stored as PNG images that are by default gzipped.  This allows raw
+tile gets to be already compressed at the cost of more expensive uncompression to
+retrieve arbitrary image sizes.
 */
 package imagetile
 
@@ -16,7 +16,7 @@ import (
 	"image/draw"
 	"image/jpeg"
 	"image/png"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"sort"
@@ -469,11 +469,13 @@ type specJSON map[string]LevelSpec
 
 // LoadTileSpec loads a TileSpec from JSON data.
 // JSON data should look like:
-// {
-//    "0": { "Resolution": [3.1, 3.1, 40.0], "TileSize": [512, 512, 40] },
-//    "1": { "Resolution": [6.2, 6.2, 40.0], "TileSize": [512, 512, 80] },
-//    ...
-// }
+//
+//	{
+//	   "0": { "Resolution": [3.1, 3.1, 40.0], "TileSize": [512, 512, 40] },
+//	   "1": { "Resolution": [6.2, 6.2, 40.0], "TileSize": [512, 512, 80] },
+//	   ...
+//	}
+//
 // Each line is a scale with a n-D resolution/voxel and a n-D tile size in voxels.
 func LoadTileSpec(jsonBytes []byte) (TileSpec, error) {
 	var config specJSON
@@ -879,7 +881,7 @@ func (d *Data) ServeHTTP(uuid dvid.UUID, ctx *datastore.VersionedCtx, w http.Res
 	case "metadata":
 		switch action {
 		case "post":
-			jsonBytes, err := ioutil.ReadAll(r.Body)
+			jsonBytes, err := io.ReadAll(r.Body)
 			if err != nil {
 				server.BadRequest(w, r, err)
 				return
@@ -1091,7 +1093,7 @@ func (d *Data) PostTile(ctx storage.Context, w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		return err
 	}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err
 	}

--- a/datatype/labelarray/labelarray.go
+++ b/datatype/labelarray/labelarray.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"image"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/url"
@@ -1920,7 +1919,7 @@ func (d *Data) sendBlock(w http.ResponseWriter, x, y, z int32, v []byte, compres
 			if err != nil {
 				return err
 			}
-			uncompressed, err = ioutil.ReadAll(zr)
+			uncompressed, err = io.ReadAll(zr)
 			if err != nil {
 				return err
 			}
@@ -2188,7 +2187,7 @@ func (d *Data) ReceiveBlocks(ctx *datastore.VersionedCtx, r io.ReadCloser, scale
 			if err != nil {
 				return fmt.Errorf("can't initiate gzip reader: %v", err)
 			}
-			uncompressed, err := ioutil.ReadAll(zr)
+			uncompressed, err := io.ReadAll(zr)
 			if err != nil {
 				return fmt.Errorf("can't read all %d bytes from gzipped block %s: %v", numBytes, bcoord, err)
 			}
@@ -2553,14 +2552,14 @@ func GetBinaryData(compression string, in io.ReadCloser, estsize int64) ([]byte,
 	switch compression {
 	case "":
 		tlog := dvid.NewTimeLog()
-		data, err = ioutil.ReadAll(in)
+		data, err = io.ReadAll(in)
 		if err != nil {
 			return nil, err
 		}
 		tlog.Debugf("read 3d uncompressed POST")
 	case "lz4":
 		tlog := dvid.NewTimeLog()
-		data, err = ioutil.ReadAll(in)
+		data, err = io.ReadAll(in)
 		if err != nil {
 			return nil, err
 		}
@@ -2581,7 +2580,7 @@ func GetBinaryData(compression string, in io.ReadCloser, estsize int64) ([]byte,
 		if err != nil {
 			return nil, err
 		}
-		data, err = ioutil.ReadAll(gr)
+		data, err = io.ReadAll(gr)
 		if err != nil {
 			return nil, err
 		}
@@ -2694,7 +2693,7 @@ func (d *Data) ServeHTTP(uuid dvid.UUID, ctx *datastore.VersionedCtx, w http.Res
 		fmt.Fprintln(w, jsonStr)
 
 	case "resolution":
-		jsonBytes, err := ioutil.ReadAll(r.Body)
+		jsonBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			server.BadRequest(w, r, err)
 			return
@@ -2842,7 +2841,7 @@ func (d *Data) handleLabels(ctx *datastore.VersionedCtx, w http.ResponseWriter, 
 		server.BadRequest(w, r, "Batch labels query must be a GET request")
 		return
 	}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		server.BadRequest(w, r, "Bad GET request body for batch query: %v", err)
 		return
@@ -3549,7 +3548,7 @@ func (d *Data) handleMerge(ctx *datastore.VersionedCtx, w http.ResponseWriter, r
 	}
 	timedLog := dvid.NewTimeLog()
 
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		server.BadRequest(w, r, "Bad POSTed data for merge.  Should be JSON.")
 		return

--- a/datatype/labelarray/labelarray_test.go
+++ b/datatype/labelarray/labelarray_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -311,7 +310,7 @@ func (v *testVolume) testGetBlocks(t *testing.T, context string, uuid dvid.UUID,
 			if err != nil {
 				t.Fatalf("can't uncompress gzip block: %v\n", err)
 			}
-			uncompressed, err = ioutil.ReadAll(zr)
+			uncompressed, err = io.ReadAll(zr)
 			if err != nil {
 				t.Fatalf("can't uncompress gzip block: %v\n", err)
 			}
@@ -487,7 +486,7 @@ func (vol *labelVol) getLabelVolume(t *testing.T, uuid dvid.UUID, compression, r
 		if err != nil {
 			t.Fatalf("Error on gzip new reader: %v\n", err)
 		}
-		uncompressed, err := ioutil.ReadAll(gr)
+		uncompressed, err := io.ReadAll(gr)
 		if err != nil {
 			t.Fatalf("Error on reading gzip: %v\n", err)
 		}
@@ -613,7 +612,7 @@ func (vol *labelVol) testBlocks(t *testing.T, context string, uuid dvid.UUID, co
 			if err != nil {
 				t.Fatalf("can't uncompress gzip block: %v\n", err)
 			}
-			uncompressed, err = ioutil.ReadAll(zr)
+			uncompressed, err = io.ReadAll(zr)
 			if err != nil {
 				t.Fatalf("can't uncompress gzip block: %v\n", err)
 			}
@@ -1085,7 +1084,7 @@ func readGzipFile(filename string) ([]byte, error) {
 	}
 	defer fz.Close()
 
-	data, err := ioutil.ReadAll(fz)
+	data, err := io.ReadAll(fz)
 	if err != nil {
 		return nil, err
 	}
@@ -1285,7 +1284,7 @@ func TestBigPostBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't open compressed block test data: %v\n", err)
 	}
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatalf("Couldn't read compressed block test data: %v\n", err)
 	}
@@ -1327,7 +1326,7 @@ func TestBigPostBlock2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't open compressed block test data: %v\n", err)
 	}
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatalf("Couldn't read compressed block test data: %v\n", err)
 	}

--- a/datatype/labelarray/mutate_test.go
+++ b/datatype/labelarray/mutate_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"reflect"
@@ -1681,7 +1680,7 @@ func (b testBody) splitmerge(t *testing.T, uuid dvid.UUID, name dvid.InstanceNam
 		resp := server.TestHTTPResponse(t, "POST", reqStr, bytes.NewBuffer(splitBytes))
 		var retbytes []byte
 		if resp.Body != nil {
-			retbytes, err = ioutil.ReadAll(resp.Body)
+			retbytes, err = io.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatalf("could not read response body for split %d of label %d: %v\n", tries, b.label, err)
 			}
@@ -1730,7 +1729,7 @@ func (b testBody) splitmerge(t *testing.T, uuid dvid.UUID, name dvid.InstanceNam
 		default:
 			var retstr string
 			if resp.Body != nil {
-				retbytes, err := ioutil.ReadAll(resp.Body)
+				retbytes, err := io.ReadAll(resp.Body)
 				if err != nil {
 					t.Fatalf("Error trying to read response body from request %q: %v\n", reqStr, err)
 					break

--- a/datatype/labelblk/labelblk.go
+++ b/datatype/labelblk/labelblk.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"image"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"strings"
@@ -1189,14 +1188,14 @@ func getBinaryData(compression string, in io.ReadCloser, estsize int64) ([]byte,
 	switch compression {
 	case "":
 		tlog := dvid.NewTimeLog()
-		data, err = ioutil.ReadAll(in)
+		data, err = io.ReadAll(in)
 		if err != nil {
 			return nil, err
 		}
 		tlog.Debugf("read 3d uncompressed POST")
 	case "lz4":
 		tlog := dvid.NewTimeLog()
-		data, err = ioutil.ReadAll(in)
+		data, err = io.ReadAll(in)
 		if err != nil {
 			return nil, err
 		}
@@ -1217,7 +1216,7 @@ func getBinaryData(compression string, in io.ReadCloser, estsize int64) ([]byte,
 		if err != nil {
 			return nil, err
 		}
-		data, err = ioutil.ReadAll(gr)
+		data, err = io.ReadAll(gr)
 		if err != nil {
 			return nil, err
 		}
@@ -1324,7 +1323,7 @@ func (d *Data) ServeHTTP(uuid dvid.UUID, ctx *datastore.VersionedCtx, w http.Res
 		fmt.Fprintln(w, jsonStr)
 
 	case "resolution":
-		jsonBytes, err := ioutil.ReadAll(r.Body)
+		jsonBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			server.BadRequest(w, r, err)
 			return
@@ -1381,7 +1380,7 @@ func (d *Data) ServeHTTP(uuid dvid.UUID, ctx *datastore.VersionedCtx, w http.Res
 			server.BadRequest(w, r, "Batch labels query must be a GET request")
 			return
 		}
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			server.BadRequest(w, r, "Bad GET request body for batch query: %v", err)
 			return

--- a/datatype/labelblk/labelblk_test.go
+++ b/datatype/labelblk/labelblk_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"reflect"
 	"sync"
@@ -512,7 +512,7 @@ func (vol *labelVol) getLabelVolume(t *testing.T, uuid dvid.UUID, compression, r
 		if err != nil {
 			t.Fatalf("Error on gzip new reader: %v\n", err)
 		}
-		uncompressed, err := ioutil.ReadAll(gr)
+		uncompressed, err := io.ReadAll(gr)
 		if err != nil {
 			t.Fatalf("Error on reading gzip: %v\n", err)
 		}

--- a/datatype/labelmap/blocks.go
+++ b/datatype/labelmap/blocks.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -170,7 +170,7 @@ func (d *Data) transcodeBlock(b blockData) (out []byte, err error) {
 			if err != nil {
 				return
 			}
-			uncompressed, err = ioutil.ReadAll(zr)
+			uncompressed, err = io.ReadAll(zr)
 			if err != nil {
 				return
 			}

--- a/datatype/labelmap/compression.go
+++ b/datatype/labelmap/compression.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 
@@ -20,14 +19,14 @@ func uncompressReaderData(compression string, in io.ReadCloser, estsize int64) (
 	switch compression {
 	case "":
 		tlog := dvid.NewTimeLog()
-		data, err = ioutil.ReadAll(in)
+		data, err = io.ReadAll(in)
 		if err != nil {
 			return nil, err
 		}
 		tlog.Debugf("read 3d uncompressed POST")
 	case "lz4":
 		tlog := dvid.NewTimeLog()
-		data, err = ioutil.ReadAll(in)
+		data, err = io.ReadAll(in)
 		if err != nil {
 			return nil, err
 		}
@@ -48,7 +47,7 @@ func uncompressReaderData(compression string, in io.ReadCloser, estsize int64) (
 		if err != nil {
 			return nil, err
 		}
-		data, err = ioutil.ReadAll(gr)
+		data, err = io.ReadAll(gr)
 		if err != nil {
 			return nil, err
 		}

--- a/datatype/labelmap/handlers.go
+++ b/datatype/labelmap/handlers.go
@@ -6,7 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -61,7 +61,7 @@ func (d *Data) handleLabels(ctx *datastore.VersionedCtx, w http.ResponseWriter, 
 		server.BadRequest(w, r, "Batch labels query must be a GET request")
 		return
 	}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		server.BadRequest(w, r, "Bad GET request body for batch query: %v", err)
 		return
@@ -111,7 +111,7 @@ func (d *Data) handleMapping(ctx *datastore.VersionedCtx, w http.ResponseWriter,
 		server.BadRequest(w, r, "Batch mapping query must be a GET request")
 		return
 	}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		server.BadRequest(w, r, "Bad GET request body for batch query: %v", err)
 		return
@@ -362,7 +362,7 @@ func (d *Data) handleIndex(ctx *datastore.VersionedCtx, w http.ResponseWriter, r
 			server.BadRequest(w, r, fmt.Errorf("no data POSTed"))
 			return
 		}
-		serialization, err := ioutil.ReadAll(r.Body)
+		serialization, err := io.ReadAll(r.Body)
 		if err != nil {
 			server.BadRequest(w, r, err)
 			return
@@ -526,7 +526,7 @@ func (d *Data) handleIndices(ctx *datastore.VersionedCtx, w http.ResponseWriter,
 		server.BadRequest(w, r, fmt.Errorf("expected data to be sent for /indices request"))
 		return
 	}
-	dataIn, err := ioutil.ReadAll(r.Body)
+	dataIn, err := io.ReadAll(r.Body)
 	if err != nil {
 		server.BadRequest(w, r, err)
 	}
@@ -583,7 +583,7 @@ func (d *Data) handleIndicesCompressed(ctx *datastore.VersionedCtx, w http.Respo
 		server.BadRequest(w, r, fmt.Errorf("expected data to be sent for /indices request"))
 		return
 	}
-	dataIn, err := ioutil.ReadAll(r.Body)
+	dataIn, err := io.ReadAll(r.Body)
 	if err != nil {
 		server.BadRequest(w, r, err)
 	}
@@ -657,7 +657,7 @@ func (d *Data) handleMappings(ctx *datastore.VersionedCtx, w http.ResponseWriter
 			server.BadRequest(w, r, fmt.Errorf("no data POSTed"))
 			return
 		}
-		serialization, err := ioutil.ReadAll(r.Body)
+		serialization, err := io.ReadAll(r.Body)
 		if err != nil {
 			server.BadRequest(w, r, err)
 		}
@@ -1177,7 +1177,7 @@ func (d *Data) handleSizes(ctx *datastore.VersionedCtx, w http.ResponseWriter, r
 		server.BadRequest(w, r, "Batch sizes query must be a GET request")
 		return
 	}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		server.BadRequest(w, r, "Bad GET request body for batch sizes query: %v", err)
 		return
@@ -1804,7 +1804,7 @@ func (d *Data) handleMerge(ctx *datastore.VersionedCtx, w http.ResponseWriter, r
 	}
 	timedLog := dvid.NewTimeLog()
 
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		server.BadRequest(w, r, "Bad POSTed data for merge.  Should be JSON.")
 		return
@@ -1840,7 +1840,7 @@ func (d *Data) handleRenumber(ctx *datastore.VersionedCtx, w http.ResponseWriter
 	}
 	timedLog := dvid.NewTimeLog()
 
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		server.BadRequest(w, r, "Bad POSTed data for renumber.  Should be JSON.")
 		return

--- a/datatype/labelmap/labelmap.go
+++ b/datatype/labelmap/labelmap.go
@@ -15,7 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"image"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -2769,7 +2769,7 @@ func (d *Data) ServeHTTP(uuid dvid.UUID, ctx *datastore.VersionedCtx, w http.Res
 		fmt.Fprintln(w, jsonStr)
 
 	case "extents":
-		jsonBytes, err := ioutil.ReadAll(r.Body)
+		jsonBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			server.BadRequest(w, r, err)
 			return
@@ -2780,7 +2780,7 @@ func (d *Data) ServeHTTP(uuid dvid.UUID, ctx *datastore.VersionedCtx, w http.Res
 		}
 
 	case "resolution":
-		jsonBytes, err := ioutil.ReadAll(r.Body)
+		jsonBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			server.BadRequest(w, r, err)
 			return

--- a/datatype/labelmap/labelmap_test.go
+++ b/datatype/labelmap/labelmap_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -357,7 +356,7 @@ func (v *testVolume) testGetBlocks(t *testing.T, context string, uuid dvid.UUID,
 			if err != nil {
 				t.Fatalf("can't uncompress gzip block: %v\n", err)
 			}
-			uncompressed, err = ioutil.ReadAll(zr)
+			uncompressed, err = io.ReadAll(zr)
 			if err != nil {
 				t.Fatalf("can't uncompress gzip block: %v\n", err)
 			}
@@ -550,7 +549,7 @@ func (vol *labelVol) getLabelVolume(t *testing.T, uuid dvid.UUID, compression, r
 		if err != nil {
 			t.Fatalf("Error on gzip new reader: %v\n", err)
 		}
-		uncompressed, err := ioutil.ReadAll(gr)
+		uncompressed, err := io.ReadAll(gr)
 		if err != nil {
 			t.Fatalf("Error on reading gzip: %v\n", err)
 		}
@@ -670,7 +669,7 @@ func (vol *labelVol) testBlocks(t *testing.T, context string, uuid dvid.UUID, co
 			if err != nil {
 				t.Fatalf("can't uncompress gzip block: %v\n", err)
 			}
-			uncompressed, err = ioutil.ReadAll(zr)
+			uncompressed, err = io.ReadAll(zr)
 			if err != nil {
 				t.Fatalf("can't uncompress gzip block: %v\n", err)
 			}
@@ -1675,7 +1674,7 @@ func readGzipFile(filename string) ([]byte, error) {
 	}
 	defer fz.Close()
 
-	data, err := ioutil.ReadAll(fz)
+	data, err := io.ReadAll(fz)
 	if err != nil {
 		return nil, err
 	}
@@ -1762,7 +1761,7 @@ func testGetBlock(t *testing.T, uuid dvid.UUID, name string, bcoord dvid.Point3d
 	if err != nil {
 		t.Fatalf("can't uncompress gzip block: %v\n", err)
 	}
-	uncompressed, err := ioutil.ReadAll(zr)
+	uncompressed, err := io.ReadAll(zr)
 	if err != nil {
 		t.Fatalf("can't uncompress gzip block: %v\n", err)
 	}
@@ -1816,7 +1815,7 @@ func decodeReturnedBlocks(t *testing.T, data []byte) []labels.PositionedBlock {
 		if err != nil {
 			t.Fatalf("can't uncompress gzip block: %v\n", err)
 		}
-		uncompressed, err := ioutil.ReadAll(zr)
+		uncompressed, err := io.ReadAll(zr)
 		if err != nil {
 			t.Fatalf("can't uncompress gzip block: %v\n", err)
 		}
@@ -2252,7 +2251,7 @@ func TestPostBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't open compressed block test data: %v\n", err)
 	}
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatalf("Couldn't read compressed block test data: %v\n", err)
 	}
@@ -2294,7 +2293,7 @@ func TestBigPostBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't open compressed block test data: %v\n", err)
 	}
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatalf("Couldn't read compressed block test data: %v\n", err)
 	}

--- a/datatype/labelmap/mutate.go
+++ b/datatype/labelmap/mutate.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 	"time"
 
@@ -354,7 +353,7 @@ func (d *Data) CleaveLabel(v dvid.VersionID, label uint64, info dvid.ModInfo, r 
 	dvid.Debugf("Cleaving subset of label %d into new label %d.\n", label, cleaveLabel)
 
 	var data []byte
-	data, err = ioutil.ReadAll(r)
+	data, err = io.ReadAll(r)
 	if err != nil {
 		err = fmt.Errorf("bad POSTed data for merge; should be JSON parsable: %v", err)
 		return

--- a/datatype/labelmap/read.go
+++ b/datatype/labelmap/read.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"sync"
 
@@ -54,7 +53,7 @@ func readStreamedBlock(r io.Reader, scale uint8) (block *labels.Block, compresse
 		return
 	}
 	var uncompressed []byte
-	uncompressed, err = ioutil.ReadAll(zr)
+	uncompressed, err = io.ReadAll(zr)
 	if err != nil {
 		err = fmt.Errorf("can't read all %d bytes from gzipped block %s: %v", numBytes, bcoord, err)
 		return

--- a/datatype/labelsz/labelsz.go
+++ b/datatype/labelsz/labelsz.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"reflect"
@@ -724,7 +723,7 @@ func (d *Data) ServeHTTP(uuid dvid.UUID, ctx *datastore.VersionedCtx, w http.Res
 			server.BadRequest(w, r, "Only GET action is available on 'counts' endpoint.")
 			return
 		}
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			server.BadRequest(w, r, "Bad GET request body for counts query: %v", err)
 			return

--- a/datatype/labelvol/labelvol.go
+++ b/datatype/labelvol/labelvol.go
@@ -1,6 +1,6 @@
 /*
-	Package labelvol supports label-specific sparse volumes.  It can be synced
-	with labelblk and is a different view of 64-bit label data.
+Package labelvol supports label-specific sparse volumes.  It can be synced
+with labelblk and is a different view of 64-bit label data.
 */
 package labelvol
 
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -1316,7 +1315,7 @@ func (d *Data) ServeHTTP(uuid dvid.UUID, ctx *datastore.VersionedCtx, w http.Res
 			server.BadRequest(w, r, "Merge requests must be POST actions.")
 			return
 		}
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			server.BadRequest(w, r, "Bad POSTed data for merge.  Should be JSON.")
 			return
@@ -1575,23 +1574,23 @@ func (d *Data) FoundSparseVol(ctx *datastore.VersionedCtx, label uint64, bounds 
 
 // GetSparseVol returns an encoded sparse volume given a label.  The encoding has the
 // following format where integers are little endian:
-//    byte     Payload descriptor:
-//               Bit 0 (LSB) - 8-bit grayscale
-//               Bit 1 - 16-bit grayscale
-//               Bit 2 - 16-bit normal
-//               ...
-//    uint8    Number of dimensions
-//    uint8    Dimension of run (typically 0 = X)
-//    byte     Reserved (to be used later)
-//    uint32    # Voxels
-//    uint32    # Spans
-//    Repeating unit of:
-//        int32   Coordinate of run start (dimension 0)
-//        int32   Coordinate of run start (dimension 1)
-//        int32   Coordinate of run start (dimension 2)
-//        int32   Length of run
-//        bytes   Optional payload dependent on first byte descriptor
 //
+//	byte     Payload descriptor:
+//	           Bit 0 (LSB) - 8-bit grayscale
+//	           Bit 1 - 16-bit grayscale
+//	           Bit 2 - 16-bit normal
+//	           ...
+//	uint8    Number of dimensions
+//	uint8    Dimension of run (typically 0 = X)
+//	byte     Reserved (to be used later)
+//	uint32    # Voxels
+//	uint32    # Spans
+//	Repeating unit of:
+//	    int32   Coordinate of run start (dimension 0)
+//	    int32   Coordinate of run start (dimension 1)
+//	    int32   Coordinate of run start (dimension 2)
+//	    int32   Length of run
+//	    bytes   Optional payload dependent on first byte descriptor
 func (d *Data) GetSparseVol(ctx *datastore.VersionedCtx, label uint64, bounds dvid.Bounds) ([]byte, error) {
 	iv := d.getMergeIV(ctx.VersionID())
 	mapping := labels.LabelMap(iv)
@@ -1703,18 +1702,18 @@ func (d *Data) GetSparseVol(ctx *datastore.VersionedCtx, label uint64, bounds dv
 
 // GetSparseCoarseVol returns an encoded sparse volume given a label.  The encoding has the
 // following format where integers are little endian:
-// 		byte     Set to 0
-// 		uint8    Number of dimensions
-// 		uint8    Dimension of run (typically 0 = X)
-// 		byte     Reserved (to be used later)
-// 		uint32    # Blocks [TODO.  0 for now]
-// 		uint32    # Spans
-// 		Repeating unit of:
-//     		int32   Block coordinate of run start (dimension 0)
-//     		int32   Block coordinate of run start (dimension 1)
-//     		int32   Block coordinate of run start (dimension 2)
-//     		int32   Length of run
 //
+//			byte     Set to 0
+//			uint8    Number of dimensions
+//			uint8    Dimension of run (typically 0 = X)
+//			byte     Reserved (to be used later)
+//			uint32    # Blocks [TODO.  0 for now]
+//			uint32    # Spans
+//			Repeating unit of:
+//	    		int32   Block coordinate of run start (dimension 0)
+//	    		int32   Block coordinate of run start (dimension 1)
+//	    		int32   Block coordinate of run start (dimension 2)
+//	    		int32   Length of run
 func (d *Data) GetSparseCoarseVol(ctx *datastore.VersionedCtx, label uint64) ([]byte, error) {
 	iv := d.getMergeIV(ctx.VersionID())
 	mapping := labels.LabelMap(iv)

--- a/datatype/roi/roi.go
+++ b/datatype/roi/roi.go
@@ -1,5 +1,5 @@
 /*
-	Package roi implements DVID support for Region-Of-Interest operations.
+Package roi implements DVID support for Region-Of-Interest operations.
 */
 package roi
 
@@ -9,7 +9,7 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"reflect"
@@ -1370,7 +1370,7 @@ func (d *Data) ServeHTTP(uuid dvid.UUID, ctx *datastore.VersionedCtx, w http.Res
 			fmt.Fprintf(w, string(jsonBytes))
 			comment = fmt.Sprintf("HTTP GET ROI %q: %d bytes", d.DataName(), len(jsonBytes))
 		case "post":
-			data, err := ioutil.ReadAll(r.Body)
+			data, err := io.ReadAll(r.Body)
 			if err != nil {
 				server.BadRequest(w, r, err)
 				return
@@ -1432,7 +1432,7 @@ func (d *Data) ServeHTTP(uuid dvid.UUID, ctx *datastore.VersionedCtx, w http.Res
 			server.BadRequest(w, r, "ptquery requires POST with list of points")
 			return
 		case "post":
-			data, err := ioutil.ReadAll(r.Body)
+			data, err := io.ReadAll(r.Body)
 			if err != nil {
 				server.BadRequest(w, r, err)
 				return

--- a/datatype/tarsupervoxels/tarsupervoxels.go
+++ b/datatype/tarsupervoxels/tarsupervoxels.go
@@ -1,5 +1,5 @@
 /*
-   Package tarsupervoxels implements DVID support for data blobs associated with supervoxels.
+Package tarsupervoxels implements DVID support for data blobs associated with supervoxels.
 */
 package tarsupervoxels
 
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -516,7 +515,7 @@ func (d *Data) handleExistence(uuid dvid.UUID, w http.ResponseWriter, r *http.Re
 		server.BadRequest(w, r, "exists query must be a GET request")
 		return
 	}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		server.BadRequest(w, r, "Bad GET request body for exists query: %v", err)
 		return
@@ -959,7 +958,7 @@ func (d *Data) ServeHTTP(uuid dvid.UUID, ctx *datastore.VersionedCtx, w http.Res
 			comment = fmt.Sprintf("HTTP DELETE supervoxel %d data of tarsupervoxels %q (%s)\n", supervoxel, d.DataName(), url)
 
 		case "post":
-			data, err := ioutil.ReadAll(r.Body)
+			data, err := io.ReadAll(r.Body)
 			if err != nil {
 				server.BadRequest(w, r, err)
 				return

--- a/dvid/serialize_test.go
+++ b/dvid/serialize_test.go
@@ -2,7 +2,7 @@ package dvid
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"os"
 	"reflect"
@@ -104,7 +104,7 @@ func readData(t *testing.T, filepath string) []byte {
 		t.Fatal(err)
 	}
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	f.Close()
 	if err != nil {
 		t.Fatal(err)

--- a/dvid/utils.go
+++ b/dvid/utils.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"mime"
@@ -193,7 +192,7 @@ func DataFromPost(r *http.Request, key string) ([]byte, error) {
 	}
 	defer f.Close()
 
-	return ioutil.ReadAll(f)
+	return io.ReadAll(f)
 }
 
 // WriteJSONFile writes an arbitrary but exportable Go object to a JSON file.
@@ -223,7 +222,7 @@ func ReadJSONFile(filename string) (value map[string]interface{}, err error) {
 	}
 	defer file.Close()
 	var fileBytes []byte
-	fileBytes, err = ioutil.ReadAll(file)
+	fileBytes, err = io.ReadAll(file)
 	if err != nil {
 		return
 	}

--- a/server/auth.go
+++ b/server/auth.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -66,7 +66,7 @@ func (auth *authData) loadAuthFile() error {
 	if err != nil {
 		return err
 	}
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}
@@ -249,7 +249,7 @@ func getEmailFromProxy(r *http.Request) (string, error) {
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("unable to get profile from %s (status %d), perhaps not logged in: %v", tc.Auth.ProxyAddress, resp.StatusCode, err)
 	}
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("unable to read /profile response from %s: %v", tc.Auth.ProxyAddress, err)
 	}

--- a/server/server_local_test.go
+++ b/server/server_local_test.go
@@ -3,7 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,7 +19,7 @@ func loadConfigFile(t *testing.T, filename string) string {
 	if err != nil {
 		t.Fatalf("couldn't open TOML file %q: %v\n", filename, err)
 	}
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatalf("couldn't read TOML file %q: %v\n", filename, err)
 	}
@@ -36,7 +36,7 @@ func TestServerInit(t *testing.T) {
 	var sent []byte
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var err error
-		sent, err = ioutil.ReadAll(r.Body)
+		sent, err = io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("couldn't read all of POSTed body: %v\n", err)
 		}

--- a/server/testing.go
+++ b/server/testing.go
@@ -12,7 +12,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -42,7 +41,7 @@ func TestHTTP(t *testing.T, method, urlStr string, payload io.Reader) []byte {
 		_, fn, line, _ := runtime.Caller(1)
 		var retstr string
 		if resp.Body != nil {
-			retbytes, err := ioutil.ReadAll(resp.Body)
+			retbytes, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Errorf("Error trying to read response body from request %q: %v [%s:%d]\n", urlStr, err, fn, line)
 			} else {
@@ -61,7 +60,7 @@ func TestHTTPError(t *testing.T, method, urlStr string, payload io.Reader) (retb
 	if resp.Code != http.StatusOK {
 		_, fn, line, _ := runtime.Caller(1)
 		if resp.Body != nil {
-			retbytes, err = ioutil.ReadAll(resp.Body)
+			retbytes, err = io.ReadAll(resp.Body)
 			if err != nil {
 				err = fmt.Errorf("error trying to read response body from request %q: %v [%s:%d]", urlStr, err, fn, line)
 				return

--- a/server/web.go
+++ b/server/web.go
@@ -944,7 +944,7 @@ func mutationsHandler(c *web.C, h http.Handler) http.Handler {
 	mutConfig := MutationLogSpec()
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		if mutConfig.Httpstore != "" {
-			buf, err := ioutil.ReadAll(r.Body)
+			buf, err := io.ReadAll(r.Body)
 			if err != nil {
 				BadRequest(w, r, "unable to read POST for mirroring: %v", err)
 				return
@@ -1254,7 +1254,7 @@ func instanceSelector(c *web.C, h http.Handler) http.Handler {
 				}
 
 			case "post":
-				value, err := ioutil.ReadAll(r.Body)
+				value, err := io.ReadAll(r.Body)
 				if err != nil {
 					BadRequest(w, r, err)
 					return
@@ -1326,7 +1326,7 @@ func instanceSelector(c *web.C, h http.Handler) http.Handler {
 		if method == "post" {
 			mirrors := instanceMirrors(data.DataUUID(), uuid)
 			if len(mirrors) > 0 {
-				buf, err := ioutil.ReadAll(r.Body)
+				buf, err := io.ReadAll(r.Body)
 				if err != nil {
 					BadRequest(w, r, "unable to read POST for mirroring: %v", err)
 					return
@@ -1438,7 +1438,7 @@ func mainHandler(w http.ResponseWriter, r *http.Request) {
 			BadRequest(w, r, err)
 			return
 		}
-		data, err := ioutil.ReadAll(rsrc)
+		data, err := io.ReadAll(rsrc)
 		if err != nil {
 			BadRequest(w, r, err)
 			return
@@ -2052,7 +2052,7 @@ func repoCommitHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 		Log  []string `json:"log"`
 	}{}
 	if r.Body != nil {
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			BadRequest(w, r, err)
 			return
@@ -2094,7 +2094,7 @@ func repoNewVersionHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 	}{}
 
 	if r.Body != nil {
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			BadRequest(w, r, err)
 			return
@@ -2151,7 +2151,7 @@ func repoBranchHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 
 	// load branch and note/uuid options
 	if r.Body != nil {
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			BadRequest(w, r, err)
 			return
@@ -2217,7 +2217,7 @@ func repoTagHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 	}{}
 
 	if r.Body != nil {
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			BadRequest(w, r, err)
 			return
@@ -2271,7 +2271,7 @@ func repoMergeHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 		BadRequest(w, r, "merge requires JSON to be POSTed per API documentation")
 		return
 	}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		BadRequest(w, r, err)
 		return
@@ -2332,7 +2332,7 @@ func repoResolveHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 		BadRequest(w, r, "merge resolving requires JSON to be POSTed per API documentation")
 		return
 	}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		BadRequest(w, r, err)
 		return

--- a/storage/filelog/filelog.go
+++ b/storage/filelog/filelog.go
@@ -3,6 +3,7 @@ package filelog
 import (
 	"encoding/binary"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -176,7 +177,7 @@ func (flogs *fileLogs) readEntireVersion(dataID, version dvid.UUID, processor fu
 		}
 		return err
 	}
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}
@@ -240,7 +241,7 @@ func (flogs *fileLogs) ReadAll(dataID, version dvid.UUID) ([]storage.LogMessage,
 		}
 		return nil, err
 	}
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +309,7 @@ func (flogs *fileLogs) StreamAll(dataID, version dvid.UUID, ch chan storage.LogM
 		}
 		return err
 	}
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}

--- a/storage/filestore/filestore.go
+++ b/storage/filestore/filestore.go
@@ -2,8 +2,8 @@
 // +build filestore
 
 /*
-	Package filestore implements a simple file-based store that fulfills
-	the KeyValueDB interface.  Keys are strings that must be valid file names.
+Package filestore implements a simple file-based store that fulfills
+the KeyValueDB interface.  Keys are strings that must be valid file names.
 */
 package filestore
 
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"hash/fnv"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -261,7 +262,7 @@ func (fs *fileStore) GetWithTimestamp(ctx storage.Context, tk storage.TKey) (dat
 		return
 	}
 	modTime = info.ModTime()
-	data, err = ioutil.ReadAll(f)
+	data, err = io.ReadAll(f)
 	f.Close()
 	return
 }

--- a/storage/gbucket/gbucket.go
+++ b/storage/gbucket/gbucket.go
@@ -36,6 +36,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -849,7 +850,7 @@ func (db *GBucket) getVhandle(obj_handle *api.ObjectHandle) ([]byte, error) {
 
 		// no error, read value and return
 		if err2 == nil {
-			value, err2 := ioutil.ReadAll(obj)
+			value, err2 := io.ReadAll(obj)
 			return value, err2
 		}
 
@@ -1047,7 +1048,7 @@ func (db *GBucket) extractVers(ctx storage.Context, baseKey storage.Key) ([]stor
 
 		// no error, read value and return
 		if err2 == nil {
-			value, err2 = ioutil.ReadAll(obj)
+			value, err2 = io.ReadAll(obj)
 			if err2 != nil {
 				return nil, nil, err2
 			}

--- a/storage/utils.go
+++ b/storage/utils.go
@@ -1,7 +1,7 @@
 package storage
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -12,7 +12,7 @@ func DataFromFile(filename string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	data, err = ioutil.ReadAll(file)
+	data, err = io.ReadAll(file)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`supervoxel %d already in index for target label 0` describes errors encountered when working with temporary label indices like when creating a label index from all merged bodies.  @stuarteberg 