### PR TITLE
Add /index-version to labelmap

### DIFF
--- a/datatype/labelmap/labelidx.go
+++ b/datatype/labelmap/labelidx.go
@@ -182,6 +182,14 @@ func (d *Data) labelIndexExists(v dvid.VersionID, label uint64) (bool, error) {
 	return store.Exists(ctx, NewLabelIndexTKey(label))
 }
 
+func getLabelIndexVersion(ctx *datastore.VersionedCtx, label uint64) (dvid.VersionID, error) {
+	store, err := datastore.GetKeyVersionGetter(ctx.Data())
+	if err != nil {
+		return 0, err
+	}
+	return store.GetVersion(ctx, NewLabelIndexTKey(label))
+}
+
 // returns nil if no Meta is found.
 // should only call getCachedLabelIndex external to this file.
 func getLabelIndex(ctx *datastore.VersionedCtx, label uint64) (*labels.Index, error) {

--- a/datatype/labelmap/labelidx.go
+++ b/datatype/labelmap/labelidx.go
@@ -97,6 +97,13 @@ func (d *Data) Initialize() {
 	}
 }
 
+// Mutation cache, currently supported only for labelmap's label indices,
+// stores every label index just before modification. This allows you to
+// reach back to its state just before any given mutation id.
+//
+// See scripts/distro-files/config-full.toml for an example of how to set cache path.
+// If [mutcache] section is not specified, no mutation cache is created.
+
 func (d *Data) getMutcache(v dvid.VersionID, mutID uint64, label uint64) (*labels.Index, error) {
 	if mutcache == nil {
 		return nil, nil

--- a/datatype/labelmap/labelidx_test.go
+++ b/datatype/labelmap/labelidx_test.go
@@ -301,12 +301,17 @@ func TestIngest(t *testing.T) {
 	idx3 = body3.getIndex(t)
 
 	ingestIndex(t, child2, idx1)
+	checkIndexVersion(t, 2, child1, child2)
 	ingestIndex(t, child2, idx2)
+	checkIndexVersion(t, 2, child2, child2)
 	ingestIndex(t, child2, idx3)
+
+	checkIndexVersion(t, 7, child1, child2)
 	blankIdx.Label = 7
 	ingestIndex(t, child2, blankIdx)
 	blankIdx.Label = 8
 	ingestIndex(t, child2, blankIdx)
+	checkIndexVersion(t, 7, child2, child2)
 
 	// Test result
 	checkSparsevolAPIs(t, child2)

--- a/datatype/labelmap/labelmap.go
+++ b/datatype/labelmap/labelmap.go
@@ -1453,6 +1453,16 @@ GET <api URL>/node/<UUID>/<data name>/proximity/<label 1 (target)>,<label 2a>,<l
 	are artificially split along block boundaries but won't be true for agglomerated
 	labels.
 	
+
+GET  <api URL>/node/<UUID>/<data name>/index-version/<label>
+
+	Returns the UUID of the the most recently stored label index for the given label.
+	Returns a status code 404 (Not Found) if label does not exist.
+
+	For example, if the label index for label 1234 was last stored in UUID d26e15,
+	the response would be the full UUID string "d26e15af06784aedbfcac1ff82684b51".
+
+
 GET  <api URL>/node/<UUID>/<data name>/index/<label>?mutid=<uint64>
 POST <api URL>/node/<UUID>/<data name>/index/<label>
 
@@ -2973,6 +2983,9 @@ func (d *Data) ServeHTTP(uuid dvid.UUID, ctx *datastore.VersionedCtx, w http.Res
 
 	case "proximity":
 		d.handleProximity(ctx, w, r, parts)
+
+	case "index-version":
+		d.handleIndexVersion(ctx, w, r, parts)
 
 	case "index":
 		d.handleIndex(ctx, w, r, parts)

--- a/datatype/labelmap/mutate_test.go
+++ b/datatype/labelmap/mutate_test.go
@@ -86,6 +86,15 @@ func checkSparsevolAPIs(t *testing.T, uuid dvid.UUID) {
 	}
 }
 
+func checkIndexVersion(t *testing.T, label uint64, expectedUUID, curUUID dvid.UUID) {
+	reqStr := fmt.Sprintf("%snode/%s/labels/index-version/%d", server.WebAPIPath, curUUID, label)
+	encoding := server.TestHTTP(t, "GET", reqStr, nil)
+	// test if encoding is same as uuid1 or else through t.Fatalf
+	if dvid.UUID(encoding) != expectedUUID {
+		t.Fatalf("Expected index version encoding to be %s, got %s\n", expectedUUID, encoding)
+	}
+}
+
 func ingestIndex(t *testing.T, uuid dvid.UUID, idx *labels.Index) {
 	serialization, err := pb.Marshal(idx)
 	if err != nil {

--- a/storage/context.go
+++ b/storage/context.go
@@ -100,9 +100,13 @@ type VersionedCtx interface {
 	// Returns upper bound key for versions.
 	MaxVersionKey(TKey) (Key, error)
 
-	// GetBestKeyVersion returns the key that most closely matches this context's version.
+	// GetBestKeyForVersion returns the key that most closely matches this context's version.
 	// If no suitable key or a tombstone is encountered closed to the version, nil is returned.
-	GetBestKeyVersion([]Key) (Key, error)
+	GetBestKeyForVersion([]Key) (Key, error)
+
+	// GetBestVersion returns the version of the stored key that most closely matches this context's version.
+	// If no suitable key or a tombstone is encountered closed to the version, a version 0 is returned.
+	GetBestVersion([]Key) (dvid.VersionID, error)
 
 	// VersionedKeyValue returns the key-value pair corresponding to this key's version
 	// given a list of key-value pairs across many versions.  If no suitable key-value

--- a/storage/keyvalue.go
+++ b/storage/keyvalue.go
@@ -243,6 +243,11 @@ type KeyValueGetter interface {
 	Exists(ctx Context, k TKey) (bool, error)
 }
 
+type KeyVersionGetter interface {
+	// GetVersions returns the VersionID of the key for the given context.
+	GetVersion(ctx Context, k TKey) (dvid.VersionID, error)
+}
+
 type OrderedKeyValueGetter interface {
 	KeyValueGetter
 


### PR DESCRIPTION
New endpoint returns UUID of last time a label index was stored. Let me know if other endpoints need this kind of version information returned. @stuarteberg 